### PR TITLE
Fix poor UX for unsupported file types on upload

### DIFF
--- a/templates/importer/configure.html
+++ b/templates/importer/configure.html
@@ -1149,7 +1149,18 @@
       method: 'POST',
       body: formData,
     })
-    .then(r => r.text())
+    .then(r => {
+      if (!r.ok) {
+        return r.text().then(html => {
+          statusEl.innerHTML = '<span style="color:#cc0f35;"><i class="fas fa-exclamation-triangle" style="margin-right:0.3rem;"></i>' +
+            (html.trim() || 'Unsupported file type.') + '</span>';
+          row.dataset.fileId = '';
+          serializeExtraDisks();
+          throw new Error('Upload rejected');
+        });
+      }
+      return r.text();
+    })
     .then(html => {
       statusEl.innerHTML = html;
       // Extract file_id from the hidden input in the returned HTML
@@ -1158,11 +1169,16 @@
       const fileIdInput = tmp.querySelector('.extra-disk-file-id');
       if (fileIdInput) {
         row.dataset.fileId = fileIdInput.value;
+      } else {
+        row.dataset.fileId = '';
       }
       serializeExtraDisks();
     })
-    .catch(() => {
-      statusEl.innerHTML = '<span style="color:#cc0f35;">Upload failed. Please try again.</span>';
+    .catch(err => {
+      if (err.message !== 'Upload rejected') {
+        statusEl.innerHTML = '<span style="color:#cc0f35;"><i class="fas fa-exclamation-triangle" style="margin-right:0.3rem;"></i>Upload failed. Please try again.</span>';
+        row.dataset.fileId = '';
+      }
     });
   }
 

--- a/templates/importer/upload.html
+++ b/templates/importer/upload.html
@@ -209,10 +209,24 @@
     }
   });
 
+  const ALLOWED_EXTENSIONS = ['.qcow2', '.vmdk', '.vhd', '.vhdx', '.raw', '.img', '.ova'];
+
   function handleFileSelect(input) {
     if (!input.files.length) return;
     const file = input.files[0];
+    const ext = '.' + file.name.split('.').pop().toLowerCase();
 
+    // Client-side extension check
+    if (!ALLOWED_EXTENSIONS.includes(ext)) {
+      showUploadError(
+        'Unsupported file type: <strong>' + ext + '</strong>. ' +
+        'Allowed formats: ' + ALLOWED_EXTENSIONS.join(', ')
+      );
+      input.value = '';
+      return;
+    }
+
+    clearUploadError();
     fileName.textContent = file.name;
     fileSize.textContent = formatBytes(file.size);
     fileInfo.style.display = 'block';
@@ -221,6 +235,24 @@
     // Update drop zone to show selected state
     dropzone.style.borderColor = '#3273dc';
     dropzone.style.background  = '#eff6ff';
+  }
+
+  function showUploadError(message) {
+    clearUploadError();
+    const el = document.createElement('div');
+    el.id = 'upload-error';
+    el.className = 'notification is-danger is-light';
+    el.style.cssText = 'margin-top:1rem;font-size:0.875rem;';
+    el.innerHTML =
+      '<button class="delete" onclick="this.parentElement.remove()"></button>' +
+      '<strong><i class="fas fa-exclamation-triangle" style="margin-right:0.4rem;"></i></strong> ' +
+      message;
+    dropzone.parentNode.insertBefore(el, dropzone.nextSibling);
+  }
+
+  function clearUploadError() {
+    const existing = document.getElementById('upload-error');
+    if (existing) existing.remove();
   }
 
   function clearFile() {
@@ -271,7 +303,15 @@
         uploadBtn.disabled = false;
         uploadBtn.innerHTML = '<span class="icon"><i class="fas fa-upload"></i></span><span>Upload &amp; Continue</span>';
         progressDiv.style.display = 'none';
+        showUploadError('Upload failed. Please check the file format and try again.');
       }
+    });
+
+    xhr.addEventListener('error', function() {
+      uploadBtn.disabled = false;
+      uploadBtn.innerHTML = '<span class="icon"><i class="fas fa-upload"></i></span><span>Upload &amp; Continue</span>';
+      progressDiv.style.display = 'none';
+      showUploadError('Upload failed — could not connect to server.');
     });
 
     xhr.open('POST', this.action);


### PR DESCRIPTION
## Summary
- Client-side extension validation on the upload page with a prominent error banner
- XHR error handling shows clear notification instead of silently resetting
- Extra disk upload now checks HTTP status — prevents corrupted entries from bad uploads

Closes #3

## Test plan
- [ ] Try uploading a .txt or .pdf file — should show red error banner immediately
- [ ] Try drag-and-drop of unsupported file — same error banner
- [ ] Upload a valid disk image — should work as before
- [ ] Add an extra disk with unsupported type — should show inline error, not corrupt the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)