### PR TITLE
Fix LXC action button alignment (closes #13)

### DIFF
--- a/templates/lxc/list.html
+++ b/templates/lxc/list.html
@@ -144,9 +144,6 @@
             </td>
             <td style="vertical-align:middle;">
               <div class="vm-actions" style="justify-content:flex-end;">
-                <a href="{% url 'lxc_detail' ct.vmid %}" class="button is-light is-small" title="Details">
-                  <i class="fas fa-info-circle"></i>
-                </a>
                 {% if ct.status == 'running' %}
                   <button class="button is-warning is-light is-small"
                           hx-post="/lxc/{{ ct.vmid }}/action/shutdown/"
@@ -182,6 +179,9 @@
                     <span>Start</span>
                   </button>
                 {% endif %}
+                <a href="{% url 'lxc_detail' ct.vmid %}" class="button is-light is-small" title="Details">
+                  <i class="fas fa-info-circle"></i>
+                </a>
               </div>
             </td>
           </tr>

--- a/templates/lxc/partials/ct_row.html
+++ b/templates/lxc/partials/ct_row.html
@@ -37,9 +37,6 @@
   </td>
   <td style="vertical-align:middle;">
     <div class="vm-actions" style="justify-content:flex-end;">
-      <a href="{% url 'lxc_detail' ct.vmid %}" class="button is-light is-small" title="Details">
-        <i class="fas fa-info-circle"></i>
-      </a>
       {% if ct.status == 'running' %}
         <button class="button is-warning is-light is-small"
                 hx-post="/lxc/{{ ct.vmid }}/action/shutdown/"
@@ -75,6 +72,9 @@
           <span>Start</span>
         </button>
       {% endif %}
+      <a href="{% url 'lxc_detail' ct.vmid %}" class="button is-light is-small" title="Details">
+        <i class="fas fa-info-circle"></i>
+      </a>
     </div>
   </td>
 </tr>


### PR DESCRIPTION
## Summary
- Moved the LXC info/details button from the left side to the right side of action buttons
- Now matches the VM inventory row layout
- Fixed in both `list.html` (initial render) and `ct_row.html` (HTMX partial)

## Test plan
- [x] Verified LXC container list shows info button on the right, after action buttons
- [x] Matches VM inventory button layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)