### PR TITLE
Add console button to LXC container list rows (partial #6)

### DIFF
--- a/templates/lxc/list.html
+++ b/templates/lxc/list.html
@@ -180,6 +180,11 @@
                     <span>Start</span>
                   </button>
                 {% endif %}
+                {% if ct.status == 'running' %}
+                  <a href="{% url 'lxc_console' ct.vmid %}" target="_blank" class="button is-dark is-small" title="Console">
+                    <i class="fas fa-terminal"></i>
+                  </a>
+                {% endif %}
                 <a href="{% url 'lxc_detail' ct.vmid %}" class="button is-light is-small" title="Details">
                   <i class="fas fa-info-circle"></i>
                 </a>

--- a/templates/lxc/partials/ct_row.html
+++ b/templates/lxc/partials/ct_row.html
@@ -72,6 +72,11 @@
           <span>Start</span>
         </button>
       {% endif %}
+      {% if ct.status == 'running' %}
+        <a href="{% url 'lxc_console' ct.vmid %}" target="_blank" class="button is-dark is-small" title="Console">
+          <i class="fas fa-terminal"></i>
+        </a>
+      {% endif %}
       <a href="{% url 'lxc_detail' ct.vmid %}" class="button is-light is-small" title="Details">
         <i class="fas fa-info-circle"></i>
       </a>


### PR DESCRIPTION
## Summary
- Adds a console (noVNC) button to the LXC container inventory list rows
- Only visible for running containers, opens console in a new tab
- Placed between action buttons and info button, consistent with existing layout
- Addresses the LXC side of #6 — VM side to be done separately by Chris

## Files changed
- `templates/lxc/list.html` — console button in inline row
- `templates/lxc/partials/ct_row.html` — console button in HTMX partial

## Test plan
- [x] Console button appears only for running containers
- [x] Opens noVNC console in new tab
- [x] Button does not appear for stopped containers
- [x] Layout matches VM action button style

🤖 Generated with [Claude Code](https://claude.com/claude-code)