### PR TITLE
Add console launch button to VM inventory rows

### DIFF
--- a/templates/inventory/list.html
+++ b/templates/inventory/list.html
@@ -197,6 +197,11 @@
                     <i class="fas fa-play"></i>
                   </button>
                 {% endif %}
+                {% if vm.status == 'running' %}
+                  <a href="{% url 'vm_console' vm.vmid %}" target="_blank" class="button is-dark is-small" title="Console">
+                    <i class="fas fa-terminal"></i>
+                  </a>
+                {% endif %}
                 <a href="{% url 'vm_detail' vm.vmid %}" class="button is-light is-small" title="Details">
                   <i class="fas fa-info-circle"></i>
                 </a>

--- a/templates/inventory/partials/vm_row.html
+++ b/templates/inventory/partials/vm_row.html
@@ -85,6 +85,11 @@
           <i class="fas fa-play"></i>
         </button>
       {% endif %}
+      {% if vm.status == 'running' %}
+        <a href="{% url 'vm_console' vm.vmid %}" target="_blank" class="button is-dark is-small" title="Console">
+          <i class="fas fa-terminal"></i>
+        </a>
+      {% endif %}
       <a href="{% url 'vm_detail' vm.vmid %}" class="button is-light is-small" title="Details">
         <i class="fas fa-info-circle"></i>
       </a>


### PR DESCRIPTION
Adds a terminal icon button to running VMs in the inventory table, matching the LXC container console button Brett added. Opens noVNC console in a new tab. Shows only for running VMs.