### PR TITLE
Fix UI spacing bugs on inventory and import pages

### DIFF
--- a/static/css/proxmigrate.css
+++ b/static/css/proxmigrate.css
@@ -344,6 +344,8 @@
   font-weight: 700;
   font-family: monospace;
   letter-spacing: 0.5px;
+  min-width: 3.5rem;
+  text-align: center;
   margin: 0.15rem;
 }
 

--- a/static/css/proxmigrate.css
+++ b/static/css/proxmigrate.css
@@ -556,6 +556,8 @@ a.stat-card-link:hover {
 .htmx-indicator { display: none; }
 .htmx-request .htmx-indicator { display: inline-block; }
 .htmx-request.htmx-indicator  { display: inline-block; }
+.spinner.htmx-indicator { display: none; }
+.htmx-request .spinner.htmx-indicator { display: inline-block; }
 
 /* Spinner */
 .spinner {


### PR DESCRIPTION
## Summary
- **#44** — Format badge alignment: Added `min-width: 3.5rem` and `text-align: center` to `.format-badge` so description text aligns consistently on the import upload page, regardless of badge label width (e.g. "VHD" vs "QCOW2").
- **#45** — Refresh button spacing: Fixed CSS specificity conflict where `.spinner` overrode `.htmx-indicator`'s `display: none`, causing the hidden spinner element to occupy space inside the refresh button on both VM and container inventory pages.

## Changes
- `static/css/proxmigrate.css` — 4 lines added (2 per fix), nothing else touched

## Test plan
- [ ] Import upload page: verify format badges (QCOW2, VMDK, VHD, etc.) have aligned description text
- [ ] VM inventory: verify refresh button has compact, even padding with no excess left-side space
- [ ] Container inventory: same refresh button check
- [ ] Click refresh on both pages — spinner should still appear during reload

Fixes #44, Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)