### PR TITLE
ACME certificate automation with Let's Encrypt and internal CA support

### DIFF
--- a/apps/certificates/acme.py
+++ b/apps/certificates/acme.py
@@ -146,10 +146,19 @@ def _sign_request(key, url, payload, kid=None, nonce=None):
 # ---------------------------------------------------------------------------
 
 _directory_cache = {}
+_active_directory_url = None
 
 
 def get_directory(directory_url, verify=True):
-    """Fetch the ACME directory JSON. Cached per URL."""
+    """Fetch the ACME directory JSON. Cached per URL.
+
+    Also stores the directory_url as the active directory so that
+    subsequent calls to _acme_post can always find it.
+    """
+    global _active_directory_url
+
+    _active_directory_url = directory_url
+
     if directory_url in _directory_cache:
         return _directory_cache[directory_url]
 
@@ -178,19 +187,14 @@ def _acme_post(key, url, payload, kid=None, verify=True, directory_url=None):
 
     Handles nonce refresh on badNonce errors (one retry).
     """
-    directory = get_directory(directory_url, verify=verify) if directory_url else None
-    nonce_url = directory_url or url
+    # Always use the directory to get nonces — some ACME servers (Smallstep)
+    # only provide nonces via the newNonce endpoint
+    dir_url = directory_url or _active_directory_url
+    if not dir_url:
+        raise AcmeError("No ACME directory URL available — call get_directory() first")
 
-    # Get a nonce — use the directory if available
-    if directory:
-        nonce = _get_nonce(directory, verify=verify)
-    else:
-        # Fall back to HEAD on the URL itself
-        nonce = requests.head(url, timeout=DEFAULT_TIMEOUT, verify=verify).headers.get(
-            "Replay-Nonce"
-        )
-        if not nonce:
-            raise AcmeError("Cannot obtain nonce")
+    directory = get_directory(dir_url, verify=verify)
+    nonce = _get_nonce(directory, verify=verify)
 
     body = _sign_request(key, url, payload, kid=kid, nonce=nonce)
     headers = {"Content-Type": "application/jose+json"}

--- a/apps/certificates/acme.py
+++ b/apps/certificates/acme.py
@@ -1,0 +1,429 @@
+"""
+ACME protocol client (RFC 8555).
+
+Pure protocol implementation using `requests` and `cryptography`.
+Works with any ACME-compliant CA: Let's Encrypt, Microsoft ADCS,
+Smallstep, Keyfactor, etc.
+
+No Django imports — this module is testable in isolation.
+"""
+
+import base64
+import hashlib
+import json
+import logging
+import time
+
+import requests
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 30
+POLL_INTERVAL = 5
+POLL_MAX_SECONDS = 300
+
+
+class AcmeError(Exception):
+    """Raised for ACME protocol errors."""
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Encoding helpers
+# ---------------------------------------------------------------------------
+
+def _b64url(data):
+    """Base64url-encode bytes without padding."""
+    if isinstance(data, str):
+        data = data.encode("utf-8")
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_int(n):
+    """Base64url-encode a positive integer."""
+    length = (n.bit_length() + 7) // 8
+    return _b64url(n.to_bytes(length, byteorder="big"))
+
+
+# ---------------------------------------------------------------------------
+# Key management
+# ---------------------------------------------------------------------------
+
+def generate_account_key():
+    """Generate an EC P-256 private key and return PEM bytes."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+def _load_key(pem_bytes):
+    """Load a PEM-encoded private key."""
+    if isinstance(pem_bytes, str):
+        pem_bytes = pem_bytes.encode("utf-8")
+    return serialization.load_pem_private_key(pem_bytes, password=None)
+
+
+def _jwk_thumbprint(key):
+    """Compute the JWK thumbprint (RFC 7638) of an EC public key."""
+    pub = key.public_key()
+    nums = pub.public_numbers()
+    jwk = {
+        "crv": "P-256",
+        "kty": "EC",
+        "x": _b64url_int(nums.x),
+        "y": _b64url_int(nums.y),
+    }
+    # Thumbprint uses lexicographic JSON with no spaces
+    jwk_json = json.dumps(jwk, sort_keys=True, separators=(",", ":"))
+    return _b64url(hashlib.sha256(jwk_json.encode("utf-8")).digest())
+
+
+def _jwk(key):
+    """Return the JWK dict for an EC public key."""
+    pub = key.public_key()
+    nums = pub.public_numbers()
+    return {
+        "crv": "P-256",
+        "kty": "EC",
+        "x": _b64url_int(nums.x),
+        "y": _b64url_int(nums.y),
+    }
+
+
+# ---------------------------------------------------------------------------
+# JWS signing
+# ---------------------------------------------------------------------------
+
+def _sign_request(key, url, payload, kid=None, nonce=None):
+    """Build a JWS-signed ACME request body.
+
+    Uses `jwk` in the header for new-account requests (kid=None),
+    and `kid` for all subsequent requests.
+    """
+    protected = {"alg": "ES256", "nonce": nonce, "url": url}
+    if kid:
+        protected["kid"] = kid
+    else:
+        protected["jwk"] = _jwk(key)
+
+    protected_b64 = _b64url(json.dumps(protected))
+
+    if payload is None:
+        # POST-as-GET: empty payload
+        payload_b64 = ""
+    elif payload == "":
+        payload_b64 = ""
+    else:
+        payload_b64 = _b64url(json.dumps(payload))
+
+    signing_input = f"{protected_b64}.{payload_b64}".encode("ascii")
+
+    from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+
+    der_sig = key.sign(signing_input, ec.ECDSA(hashes.SHA256()))
+    r, s = decode_dss_signature(der_sig)
+    # ES256 signature is r || s, each 32 bytes
+    sig_bytes = r.to_bytes(32, byteorder="big") + s.to_bytes(32, byteorder="big")
+
+    return {
+        "protected": protected_b64,
+        "payload": payload_b64,
+        "signature": _b64url(sig_bytes),
+    }
+
+
+# ---------------------------------------------------------------------------
+# ACME directory & nonce
+# ---------------------------------------------------------------------------
+
+_directory_cache = {}
+
+
+def get_directory(directory_url, verify=True):
+    """Fetch the ACME directory JSON. Cached per URL."""
+    if directory_url in _directory_cache:
+        return _directory_cache[directory_url]
+
+    resp = requests.get(directory_url, timeout=DEFAULT_TIMEOUT, verify=verify)
+    if resp.status_code != 200:
+        raise AcmeError(f"Failed to fetch ACME directory: HTTP {resp.status_code}")
+
+    directory = resp.json()
+    _directory_cache[directory_url] = directory
+    return directory
+
+
+def _get_nonce(directory, verify=True):
+    """Fetch a fresh anti-replay nonce."""
+    resp = requests.head(
+        directory["newNonce"], timeout=DEFAULT_TIMEOUT, verify=verify,
+    )
+    nonce = resp.headers.get("Replay-Nonce")
+    if not nonce:
+        raise AcmeError("No Replay-Nonce header in newNonce response")
+    return nonce
+
+
+def _acme_post(key, url, payload, kid=None, verify=True, directory_url=None):
+    """Send a signed ACME POST request and return the response.
+
+    Handles nonce refresh on badNonce errors (one retry).
+    """
+    directory = get_directory(directory_url, verify=verify) if directory_url else None
+    nonce_url = directory_url or url
+
+    # Get a nonce — use the directory if available
+    if directory:
+        nonce = _get_nonce(directory, verify=verify)
+    else:
+        # Fall back to HEAD on the URL itself
+        nonce = requests.head(url, timeout=DEFAULT_TIMEOUT, verify=verify).headers.get(
+            "Replay-Nonce"
+        )
+        if not nonce:
+            raise AcmeError("Cannot obtain nonce")
+
+    body = _sign_request(key, url, payload, kid=kid, nonce=nonce)
+    headers = {"Content-Type": "application/jose+json"}
+    resp = requests.post(url, json=body, headers=headers, timeout=DEFAULT_TIMEOUT, verify=verify)
+
+    # Retry once on badNonce
+    if resp.status_code == 400:
+        try:
+            err = resp.json()
+            if err.get("type", "").endswith("badNonce"):
+                new_nonce = resp.headers.get("Replay-Nonce")
+                if not new_nonce and directory:
+                    new_nonce = _get_nonce(directory, verify=verify)
+                if new_nonce:
+                    body = _sign_request(key, url, payload, kid=kid, nonce=new_nonce)
+                    resp = requests.post(
+                        url, json=body, headers=headers,
+                        timeout=DEFAULT_TIMEOUT, verify=verify,
+                    )
+        except (ValueError, KeyError):
+            pass
+
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Account management
+# ---------------------------------------------------------------------------
+
+def register_account(account_key_pem, directory_url, email=None, verify=True):
+    """Register an ACME account (or find existing). Returns the account URL."""
+    key = _load_key(account_key_pem)
+    directory = get_directory(directory_url, verify=verify)
+
+    payload = {"termsOfServiceAgreed": True}
+    if email:
+        payload["contact"] = [f"mailto:{email}"]
+
+    nonce = _get_nonce(directory, verify=verify)
+    body = _sign_request(key, directory["newAccount"], payload, nonce=nonce)
+    headers = {"Content-Type": "application/jose+json"}
+
+    resp = requests.post(
+        directory["newAccount"], json=body, headers=headers,
+        timeout=DEFAULT_TIMEOUT, verify=verify,
+    )
+
+    if resp.status_code not in (200, 201):
+        raise AcmeError(
+            f"Account registration failed: HTTP {resp.status_code} — {resp.text}"
+        )
+
+    account_url = resp.headers.get("Location")
+    if not account_url:
+        raise AcmeError("No Location header in account registration response")
+
+    logger.info("ACME account registered/found: %s", account_url)
+    return account_url
+
+
+# ---------------------------------------------------------------------------
+# Certificate ordering
+# ---------------------------------------------------------------------------
+
+def create_order(account_key_pem, account_url, directory_url, domain, verify=True):
+    """Create a new certificate order. Returns (order_url, order_body)."""
+    key = _load_key(account_key_pem)
+    directory = get_directory(directory_url, verify=verify)
+
+    payload = {
+        "identifiers": [{"type": "dns", "value": domain}],
+    }
+
+    resp = _acme_post(
+        key, directory["newOrder"], payload,
+        kid=account_url, verify=verify, directory_url=directory_url,
+    )
+
+    if resp.status_code not in (200, 201):
+        raise AcmeError(f"Order creation failed: HTTP {resp.status_code} — {resp.text}")
+
+    order_url = resp.headers.get("Location", "")
+    return order_url, resp.json()
+
+
+def get_authorization(account_key_pem, account_url, auth_url, verify=True):
+    """Fetch an authorization object. Returns the JSON body."""
+    key = _load_key(account_key_pem)
+    resp = _acme_post(key, auth_url, None, kid=account_url, verify=verify)
+
+    if resp.status_code != 200:
+        raise AcmeError(f"Authorization fetch failed: HTTP {resp.status_code}")
+
+    return resp.json()
+
+
+def get_http01_challenge(authorization):
+    """Extract the HTTP-01 challenge from an authorization, or None."""
+    for chall in authorization.get("challenges", []):
+        if chall.get("type") == "http-01":
+            return chall
+    return None
+
+
+def get_dns01_challenge(authorization):
+    """Extract the DNS-01 challenge from an authorization, or None."""
+    for chall in authorization.get("challenges", []):
+        if chall.get("type") == "dns-01":
+            return chall
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Challenge computation
+# ---------------------------------------------------------------------------
+
+def compute_key_authorization(account_key_pem, token):
+    """Compute the key authorization string for HTTP-01: token.thumbprint."""
+    key = _load_key(account_key_pem)
+    thumbprint = _jwk_thumbprint(key)
+    return f"{token}.{thumbprint}"
+
+
+def compute_dns01_txt_value(account_key_pem, token):
+    """Compute the DNS-01 TXT record value: base64url(SHA256(keyAuthorization))."""
+    key_auth = compute_key_authorization(account_key_pem, token)
+    digest = hashlib.sha256(key_auth.encode("utf-8")).digest()
+    return _b64url(digest)
+
+
+# ---------------------------------------------------------------------------
+# Challenge response & polling
+# ---------------------------------------------------------------------------
+
+def respond_to_challenge(account_key_pem, account_url, challenge_url, verify=True):
+    """Tell the ACME server the challenge is ready for validation."""
+    key = _load_key(account_key_pem)
+    resp = _acme_post(
+        key, challenge_url, {}, kid=account_url, verify=verify,
+    )
+
+    if resp.status_code not in (200, 202):
+        raise AcmeError(
+            f"Challenge response failed: HTTP {resp.status_code} — {resp.text}"
+        )
+
+    return resp.json()
+
+
+def poll_order(account_key_pem, account_url, order_url, verify=True,
+               timeout=POLL_MAX_SECONDS):
+    """Poll an order until it reaches 'ready' or 'valid' state.
+
+    Returns the order JSON. Raises AcmeError on 'invalid' or timeout.
+    """
+    key = _load_key(account_key_pem)
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        resp = _acme_post(key, order_url, None, kid=account_url, verify=verify)
+
+        if resp.status_code != 200:
+            raise AcmeError(f"Order poll failed: HTTP {resp.status_code}")
+
+        order = resp.json()
+        status = order.get("status")
+
+        if status in ("ready", "valid"):
+            return order
+        if status == "invalid":
+            raise AcmeError(f"Order became invalid: {json.dumps(order)}")
+
+        logger.debug("Order status: %s — polling again in %ds", status, POLL_INTERVAL)
+        time.sleep(POLL_INTERVAL)
+
+    raise AcmeError(f"Order did not become ready within {timeout}s")
+
+
+# ---------------------------------------------------------------------------
+# Finalization & certificate download
+# ---------------------------------------------------------------------------
+
+def generate_csr(domain):
+    """Generate a fresh RSA 2048 key + CSR for the given domain.
+
+    Returns (private_key_pem, csr_der).
+    """
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    csr = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, domain)]))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(domain)]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    csr_der = csr.public_bytes(serialization.Encoding.DER)
+
+    return key_pem, csr_der
+
+
+def finalize_order(account_key_pem, account_url, finalize_url, csr_der, verify=True):
+    """Submit a CSR to finalize the order. Returns the updated order JSON."""
+    key = _load_key(account_key_pem)
+    payload = {"csr": _b64url(csr_der)}
+
+    resp = _acme_post(
+        key, finalize_url, payload, kid=account_url, verify=verify,
+    )
+
+    if resp.status_code not in (200, 201):
+        raise AcmeError(
+            f"Order finalization failed: HTTP {resp.status_code} — {resp.text}"
+        )
+
+    return resp.json()
+
+
+def download_certificate(account_key_pem, account_url, cert_url, verify=True):
+    """Download the issued certificate chain. Returns PEM bytes."""
+    key = _load_key(account_key_pem)
+    resp = _acme_post(key, cert_url, None, kid=account_url, verify=verify)
+
+    if resp.status_code != 200:
+        raise AcmeError(
+            f"Certificate download failed: HTTP {resp.status_code} — {resp.text}"
+        )
+
+    return resp.content

--- a/apps/certificates/acme.py
+++ b/apps/certificates/acme.py
@@ -259,13 +259,18 @@ def register_account(account_key_pem, directory_url, email=None, verify=True):
 # Certificate ordering
 # ---------------------------------------------------------------------------
 
-def create_order(account_key_pem, account_url, directory_url, domain, verify=True):
+def create_order(account_key_pem, account_url, directory_url, domain,
+                  ip_sans=None, verify=True):
     """Create a new certificate order. Returns (order_url, order_body)."""
     key = _load_key(account_key_pem)
     directory = get_directory(directory_url, verify=verify)
 
+    identifiers = [{"type": "dns", "value": domain}]
+    for ip in (ip_sans or []):
+        identifiers.append({"type": "ip", "value": ip.strip()})
+
     payload = {
-        "identifiers": [{"type": "dns", "value": domain}],
+        "identifiers": identifiers,
     }
 
     resp = _acme_post(
@@ -377,11 +382,13 @@ def poll_order(account_key_pem, account_url, order_url, verify=True,
 # Finalization & certificate download
 # ---------------------------------------------------------------------------
 
-def generate_csr(domain):
+def generate_csr(domain, ip_sans=None):
     """Generate a fresh RSA 2048 key + CSR for the given domain.
 
     Returns (private_key_pem, csr_der).
     """
+    import ipaddress as _ipaddress
+
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     key_pem = key.private_bytes(
         encoding=serialization.Encoding.PEM,
@@ -389,11 +396,18 @@ def generate_csr(domain):
         encryption_algorithm=serialization.NoEncryption(),
     )
 
+    san_list = [x509.DNSName(domain)]
+    for ip in (ip_sans or []):
+        try:
+            san_list.append(x509.IPAddress(_ipaddress.ip_address(ip.strip())))
+        except ValueError:
+            logger.warning("Skipping invalid IP SAN: %s", ip)
+
     csr = (
         x509.CertificateSigningRequestBuilder()
         .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, domain)]))
         .add_extension(
-            x509.SubjectAlternativeName([x509.DNSName(domain)]),
+            x509.SubjectAlternativeName(san_list),
             critical=False,
         )
         .sign(key, hashes.SHA256())

--- a/apps/certificates/acme.py
+++ b/apps/certificates/acme.py
@@ -198,26 +198,34 @@ def _acme_post(key, url, payload, kid=None, verify=True, directory_url=None):
 
     body = _sign_request(key, url, payload, kid=kid, nonce=nonce)
     headers = {"Content-Type": "application/jose+json"}
-    resp = requests.post(url, json=body, headers=headers, timeout=DEFAULT_TIMEOUT, verify=verify)
 
-    # Retry once on badNonce
-    if resp.status_code == 400:
-        try:
-            err = resp.json()
-            if err.get("type", "").endswith("badNonce"):
-                new_nonce = resp.headers.get("Replay-Nonce")
-                if not new_nonce and directory:
-                    new_nonce = _get_nonce(directory, verify=verify)
-                if new_nonce:
-                    body = _sign_request(key, url, payload, kid=kid, nonce=new_nonce)
-                    resp = requests.post(
-                        url, json=body, headers=headers,
-                        timeout=DEFAULT_TIMEOUT, verify=verify,
-                    )
-        except (ValueError, KeyError):
-            pass
+    # Use a fresh session for each POST to avoid stale TLS connections
+    # (nginx reloads during challenge setup can break connection pools)
+    session = requests.Session()
+    session.verify = verify
+    try:
+        resp = session.post(url, json=body, headers=headers, timeout=DEFAULT_TIMEOUT)
 
-    return resp
+        # Retry once on badNonce
+        if resp.status_code == 400:
+            try:
+                err = resp.json()
+                if err.get("type", "").endswith("badNonce"):
+                    new_nonce = resp.headers.get("Replay-Nonce")
+                    if not new_nonce and directory:
+                        new_nonce = _get_nonce(directory, verify=verify)
+                    if new_nonce:
+                        body = _sign_request(key, url, payload, kid=kid, nonce=new_nonce)
+                        resp = session.post(
+                            url, json=body, headers=headers,
+                            timeout=DEFAULT_TIMEOUT,
+                        )
+            except (ValueError, KeyError):
+                pass
+
+        return resp
+    finally:
+        session.close()
 
 
 # ---------------------------------------------------------------------------

--- a/apps/certificates/dns_providers.py
+++ b/apps/certificates/dns_providers.py
@@ -1,0 +1,446 @@
+"""
+DNS provider API integrations for automated ACME DNS-01 challenges.
+
+Each provider implements create_txt_record() and delete_txt_record().
+No Django imports — this module is testable in isolation.
+"""
+
+import json
+import logging
+import time
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+DNS_PROPAGATION_DELAY = 10  # seconds to wait after record creation
+
+
+class DnsProviderError(Exception):
+    """Raised when a DNS provider API call fails."""
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Cloudflare
+# ---------------------------------------------------------------------------
+
+def _cloudflare_headers(api_token):
+    return {
+        "Authorization": f"Bearer {api_token}",
+        "Content-Type": "application/json",
+    }
+
+
+def cloudflare_create_txt(domain, value, api_token, zone_id=""):
+    """Create a TXT record via Cloudflare API.
+
+    If zone_id is empty, auto-discovers it from the domain.
+    Returns the record ID for later deletion.
+    """
+    headers = _cloudflare_headers(api_token)
+
+    if not zone_id:
+        zone_id = _cloudflare_find_zone(domain, headers)
+
+    record_name = f"_acme-challenge.{domain}"
+
+    # Delete any existing ACME challenge records first
+    _cloudflare_delete_existing(zone_id, record_name, headers)
+
+    resp = requests.post(
+        f"https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records",
+        headers=headers,
+        json={
+            "type": "TXT",
+            "name": record_name,
+            "content": value,
+            "ttl": 120,
+        },
+        timeout=30,
+    )
+    data = resp.json()
+    if not data.get("success"):
+        errors = data.get("errors", [])
+        raise DnsProviderError(f"Cloudflare create TXT failed: {errors}")
+
+    record_id = data["result"]["id"]
+    logger.info("Cloudflare TXT record created: %s (ID: %s)", record_name, record_id)
+    return record_id
+
+
+def cloudflare_delete_txt(domain, api_token, zone_id="", record_id=""):
+    """Delete the ACME challenge TXT record from Cloudflare."""
+    headers = _cloudflare_headers(api_token)
+
+    if not zone_id:
+        zone_id = _cloudflare_find_zone(domain, headers)
+
+    if record_id:
+        resp = requests.delete(
+            f"https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records/{record_id}",
+            headers=headers,
+            timeout=30,
+        )
+        if resp.status_code not in (200, 404):
+            logger.warning("Cloudflare delete record %s returned %d", record_id, resp.status_code)
+    else:
+        _cloudflare_delete_existing(zone_id, f"_acme-challenge.{domain}", headers)
+
+
+def _cloudflare_find_zone(domain, headers):
+    """Auto-discover the Cloudflare zone ID from the domain."""
+    # Try progressively shorter domain parts (e.g. sub.example.com → example.com)
+    parts = domain.split(".")
+    for i in range(len(parts) - 1):
+        zone_name = ".".join(parts[i:])
+        resp = requests.get(
+            "https://api.cloudflare.com/client/v4/zones",
+            headers=headers,
+            params={"name": zone_name, "status": "active"},
+            timeout=30,
+        )
+        data = resp.json()
+        if data.get("success") and data.get("result"):
+            return data["result"][0]["id"]
+
+    raise DnsProviderError(
+        f"Could not find Cloudflare zone for {domain}. "
+        f"Provide the Zone ID manually."
+    )
+
+
+def _cloudflare_delete_existing(zone_id, record_name, headers):
+    """Delete any existing TXT records with the given name."""
+    resp = requests.get(
+        f"https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records",
+        headers=headers,
+        params={"type": "TXT", "name": record_name},
+        timeout=30,
+    )
+    data = resp.json()
+    if data.get("success"):
+        for record in data.get("result", []):
+            requests.delete(
+                f"https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records/{record['id']}",
+                headers=headers,
+                timeout=30,
+            )
+
+
+# ---------------------------------------------------------------------------
+# AWS Route 53
+# ---------------------------------------------------------------------------
+
+def route53_create_txt(domain, value, api_token, api_secret="", zone_id=""):
+    """Create a TXT record via AWS Route 53.
+
+    api_token = AWS Access Key ID
+    api_secret = AWS Secret Access Key
+    zone_id = Hosted Zone ID (e.g. Z1234567890)
+    """
+    try:
+        import boto3
+    except ImportError:
+        raise DnsProviderError(
+            "AWS Route 53 requires the boto3 package. "
+            "Install it with: pip install boto3"
+        )
+
+    client = boto3.client(
+        "route53",
+        aws_access_key_id=api_token,
+        aws_secret_access_key=api_secret,
+    )
+
+    record_name = f"_acme-challenge.{domain}"
+
+    client.change_resource_record_sets(
+        HostedZoneId=zone_id,
+        ChangeBatch={
+            "Changes": [{
+                "Action": "UPSERT",
+                "ResourceRecordSet": {
+                    "Name": record_name,
+                    "Type": "TXT",
+                    "TTL": 120,
+                    "ResourceRecords": [{"Value": f'"{value}"'}],
+                },
+            }],
+        },
+    )
+    logger.info("Route 53 TXT record upserted: %s", record_name)
+    return ""
+
+
+def route53_delete_txt(domain, api_token, api_secret="", zone_id=""):
+    """Delete the ACME challenge TXT record from Route 53."""
+    try:
+        import boto3
+    except ImportError:
+        return
+
+    client = boto3.client(
+        "route53",
+        aws_access_key_id=api_token,
+        aws_secret_access_key=api_secret,
+    )
+
+    record_name = f"_acme-challenge.{domain}"
+
+    # Get current record value to delete it
+    try:
+        resp = client.list_resource_record_sets(
+            HostedZoneId=zone_id,
+            StartRecordName=record_name,
+            StartRecordType="TXT",
+            MaxItems="1",
+        )
+        for rrs in resp.get("ResourceRecordSets", []):
+            if rrs["Name"].rstrip(".") == record_name and rrs["Type"] == "TXT":
+                client.change_resource_record_sets(
+                    HostedZoneId=zone_id,
+                    ChangeBatch={
+                        "Changes": [{
+                            "Action": "DELETE",
+                            "ResourceRecordSet": rrs,
+                        }],
+                    },
+                )
+                logger.info("Route 53 TXT record deleted: %s", record_name)
+    except Exception as exc:
+        logger.warning("Route 53 delete failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Azure DNS
+# ---------------------------------------------------------------------------
+
+def azure_create_txt(domain, value, api_token, zone_id=""):
+    """Create a TXT record via Azure DNS REST API.
+
+    api_token = Azure Bearer token (from service principal or managed identity)
+    zone_id = Full resource ID: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/dnsZones/{zone}
+    """
+    record_name = "_acme-challenge"
+    url = (
+        f"https://management.azure.com{zone_id}"
+        f"/TXT/{record_name}?api-version=2018-05-01"
+    )
+
+    resp = requests.put(
+        url,
+        headers={
+            "Authorization": f"Bearer {api_token}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "properties": {
+                "TTL": 120,
+                "TXTRecords": [{"value": [value]}],
+            },
+        },
+        timeout=30,
+    )
+
+    if resp.status_code not in (200, 201):
+        raise DnsProviderError(f"Azure DNS create TXT failed: {resp.status_code} {resp.text}")
+
+    logger.info("Azure DNS TXT record created: _acme-challenge.%s", domain)
+    return ""
+
+
+def azure_delete_txt(domain, api_token, zone_id=""):
+    """Delete the ACME challenge TXT record from Azure DNS."""
+    record_name = "_acme-challenge"
+    url = (
+        f"https://management.azure.com{zone_id}"
+        f"/TXT/{record_name}?api-version=2018-05-01"
+    )
+
+    resp = requests.delete(
+        url,
+        headers={"Authorization": f"Bearer {api_token}"},
+        timeout=30,
+    )
+    if resp.status_code not in (200, 204, 404):
+        logger.warning("Azure DNS delete returned %d", resp.status_code)
+
+
+# ---------------------------------------------------------------------------
+# GoDaddy
+# ---------------------------------------------------------------------------
+
+def godaddy_create_txt(domain, value, api_token, api_secret="", zone_id=""):
+    """Create a TXT record via GoDaddy API.
+
+    api_token = GoDaddy API Key
+    api_secret = GoDaddy API Secret
+    zone_id = not used (domain is the zone)
+    """
+    # Find the base domain (GoDaddy uses the registerable domain as the zone)
+    parts = domain.split(".")
+    base_domain = ".".join(parts[-2:])
+    record_name = "_acme-challenge"
+    if len(parts) > 2:
+        record_name = f"_acme-challenge.{'.'.join(parts[:-2])}"
+
+    resp = requests.put(
+        f"https://api.godaddy.com/v1/domains/{base_domain}/records/TXT/{record_name}",
+        headers={
+            "Authorization": f"sso-key {api_token}:{api_secret}",
+            "Content-Type": "application/json",
+        },
+        json=[{"data": value, "ttl": 600}],
+        timeout=30,
+    )
+
+    if resp.status_code not in (200, 204):
+        raise DnsProviderError(f"GoDaddy create TXT failed: {resp.status_code} {resp.text}")
+
+    logger.info("GoDaddy TXT record created: %s.%s", record_name, base_domain)
+    return ""
+
+
+def godaddy_delete_txt(domain, api_token, api_secret="", zone_id=""):
+    """Delete the ACME challenge TXT record from GoDaddy."""
+    parts = domain.split(".")
+    base_domain = ".".join(parts[-2:])
+    record_name = "_acme-challenge"
+    if len(parts) > 2:
+        record_name = f"_acme-challenge.{'.'.join(parts[:-2])}"
+
+    # GoDaddy doesn't have a delete endpoint — overwrite with empty
+    resp = requests.put(
+        f"https://api.godaddy.com/v1/domains/{base_domain}/records/TXT/{record_name}",
+        headers={
+            "Authorization": f"sso-key {api_token}:{api_secret}",
+            "Content-Type": "application/json",
+        },
+        json=[{"data": "removed", "ttl": 600}],
+        timeout=30,
+    )
+    if resp.status_code not in (200, 204):
+        logger.warning("GoDaddy delete returned %d", resp.status_code)
+
+
+# ---------------------------------------------------------------------------
+# DigitalOcean
+# ---------------------------------------------------------------------------
+
+def digitalocean_create_txt(domain, value, api_token, zone_id=""):
+    """Create a TXT record via DigitalOcean API.
+
+    api_token = DigitalOcean personal access token
+    zone_id = not used (domain is the zone)
+    """
+    parts = domain.split(".")
+    base_domain = ".".join(parts[-2:])
+    record_name = "_acme-challenge"
+    if len(parts) > 2:
+        record_name = f"_acme-challenge.{'.'.join(parts[:-2])}"
+
+    # Delete existing first
+    _digitalocean_delete_existing(base_domain, record_name, api_token)
+
+    resp = requests.post(
+        f"https://api.digitalocean.com/v2/domains/{base_domain}/records",
+        headers={
+            "Authorization": f"Bearer {api_token}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "type": "TXT",
+            "name": record_name,
+            "data": value,
+            "ttl": 120,
+        },
+        timeout=30,
+    )
+
+    if resp.status_code not in (200, 201):
+        raise DnsProviderError(f"DigitalOcean create TXT failed: {resp.status_code} {resp.text}")
+
+    record_id = resp.json().get("domain_record", {}).get("id", "")
+    logger.info("DigitalOcean TXT record created: %s.%s", record_name, base_domain)
+    return str(record_id)
+
+
+def digitalocean_delete_txt(domain, api_token, zone_id=""):
+    """Delete the ACME challenge TXT record from DigitalOcean."""
+    parts = domain.split(".")
+    base_domain = ".".join(parts[-2:])
+    record_name = "_acme-challenge"
+    if len(parts) > 2:
+        record_name = f"_acme-challenge.{'.'.join(parts[:-2])}"
+
+    _digitalocean_delete_existing(base_domain, record_name, api_token)
+
+
+def _digitalocean_delete_existing(base_domain, record_name, api_token):
+    """Delete existing TXT records matching the name."""
+    headers = {"Authorization": f"Bearer {api_token}"}
+    resp = requests.get(
+        f"https://api.digitalocean.com/v2/domains/{base_domain}/records",
+        headers=headers,
+        params={"type": "TXT", "name": f"{record_name}.{base_domain}"},
+        timeout=30,
+    )
+    if resp.status_code == 200:
+        for record in resp.json().get("domain_records", []):
+            if record.get("name") == record_name:
+                requests.delete(
+                    f"https://api.digitalocean.com/v2/domains/{base_domain}/records/{record['id']}",
+                    headers=headers,
+                    timeout=30,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher — unified interface
+# ---------------------------------------------------------------------------
+
+def create_txt_record(dns_provider, domain, value, api_token, api_secret="", zone_id=""):
+    """Create a DNS TXT record using the configured provider.
+
+    Returns a record_id string (may be empty for some providers).
+    Raises DnsProviderError on failure.
+    """
+    providers = {
+        "cloudflare": lambda: cloudflare_create_txt(domain, value, api_token, zone_id),
+        "route53": lambda: route53_create_txt(domain, value, api_token, api_secret, zone_id),
+        "azure": lambda: azure_create_txt(domain, value, api_token, zone_id),
+        "godaddy": lambda: godaddy_create_txt(domain, value, api_token, api_secret, zone_id),
+        "digitalocean": lambda: digitalocean_create_txt(domain, value, api_token, zone_id),
+    }
+
+    if dns_provider not in providers:
+        raise DnsProviderError(f"Unsupported DNS provider: {dns_provider}")
+
+    record_id = providers[dns_provider]()
+
+    # Wait for propagation
+    logger.info("Waiting %ds for DNS propagation...", DNS_PROPAGATION_DELAY)
+    time.sleep(DNS_PROPAGATION_DELAY)
+
+    return record_id
+
+
+def delete_txt_record(dns_provider, domain, api_token, api_secret="", zone_id="", record_id=""):
+    """Delete a DNS TXT record using the configured provider.
+
+    Best-effort — logs warnings but does not raise on failure.
+    """
+    try:
+        if dns_provider == "cloudflare":
+            cloudflare_delete_txt(domain, api_token, zone_id, record_id)
+        elif dns_provider == "route53":
+            route53_delete_txt(domain, api_token, api_secret, zone_id)
+        elif dns_provider == "azure":
+            azure_delete_txt(domain, api_token, zone_id)
+        elif dns_provider == "godaddy":
+            godaddy_delete_txt(domain, api_token, api_secret, zone_id)
+        elif dns_provider == "digitalocean":
+            digitalocean_delete_txt(domain, api_token, zone_id)
+    except Exception as exc:
+        logger.warning("Failed to delete TXT record via %s: %s", dns_provider, exc)

--- a/apps/certificates/helpers.py
+++ b/apps/certificates/helpers.py
@@ -1,0 +1,129 @@
+"""
+Certificate management helper functions.
+
+Shared by views.py and tasks.py — file I/O, nginx operations,
+certificate parsing. No HTTP request/response handling.
+"""
+
+import logging
+import os
+import re
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+CERT_DIR = "/opt/proxmigrate/certs"
+CERT_FILE = os.path.join(CERT_DIR, "proxmigrate.crt")
+KEY_FILE = os.path.join(CERT_DIR, "proxmigrate.key")
+CSR_KEY_FILE = os.path.join(CERT_DIR, "proxmigrate.csr.key")
+PENDING_CSR_FILE = os.path.join(CERT_DIR, "pending.csr")
+ENV_FILE = "/opt/proxmigrate/.env"
+
+NGINX_CONF_PATHS = [
+    "/etc/nginx/sites-available/proxmigrate",
+    "/etc/nginx/conf.d/proxmigrate.conf",
+]
+
+
+def get_cert_info():
+    """Parse the current certificate and return a rich info dict, or None."""
+    if not os.path.exists(CERT_FILE):
+        return None
+    try:
+        from cryptography import x509
+        from cryptography.hazmat.backends import default_backend
+
+        with open(CERT_FILE, "rb") as f:
+            cert = x509.load_pem_x509_certificate(f.read(), default_backend())
+
+        san_parts = []
+        try:
+            san_ext = cert.extensions.get_extension_for_class(
+                x509.SubjectAlternativeName,
+            )
+            for name in san_ext.value:
+                if isinstance(name, x509.DNSName):
+                    san_parts.append(f"DNS:{name.value}")
+                elif isinstance(name, x509.IPAddress):
+                    san_parts.append(f"IP:{name.value}")
+        except x509.ExtensionNotFound:
+            pass
+
+        return {
+            "subject": cert.subject.rfc4514_string(),
+            "issuer": cert.issuer.rfc4514_string(),
+            "not_before": cert.not_valid_before_utc,
+            "not_after": cert.not_valid_after_utc,
+            "serial": format(cert.serial_number, "X"),
+            "san": ", ".join(san_parts) or "\u2014",
+            "is_self_signed": cert.subject == cert.issuer,
+        }
+    except Exception as exc:
+        logger.warning("get_cert_info: %s", exc)
+        return {"error": str(exc)}
+
+
+def get_pending_csr():
+    """Return the pending CSR PEM text, or None."""
+    if not os.path.exists(PENDING_CSR_FILE):
+        return None
+    try:
+        with open(PENDING_CSR_FILE, "rb") as f:
+            return f.read().decode("utf-8")
+    except OSError:
+        return None
+
+
+def find_nginx_conf():
+    """Return the first nginx config path that exists, or None."""
+    for p in NGINX_CONF_PATHS:
+        if os.path.exists(p):
+            return p
+    return None
+
+
+def get_current_port():
+    """Read the WEB_PORT from .env. Defaults to 8443."""
+    try:
+        if os.path.exists(ENV_FILE):
+            with open(ENV_FILE) as f:
+                for line in f:
+                    m = re.match(r"^WEB_PORT=(\d+)", line.strip())
+                    if m:
+                        return int(m.group(1))
+    except Exception:
+        pass
+    return 8443
+
+
+def reload_nginx():
+    """Reload nginx. Raises RuntimeError on failure."""
+    result = subprocess.run(
+        ["sudo", "nginx", "-s", "reload"],
+        capture_output=True, text=True, shell=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"nginx reload failed: {result.stderr.strip()}")
+
+
+def install_cert_and_key(cert_content, key_content):
+    """Write certificate and key files to disk."""
+    os.makedirs(CERT_DIR, exist_ok=True)
+    with open(CERT_FILE, "wb") as f:
+        f.write(cert_content)
+    with open(KEY_FILE, "wb") as f:
+        f.write(key_content)
+    os.chmod(KEY_FILE, 0o600)
+
+
+def validate_cert_key_pair(cert_content, key_content):
+    """Raise ValueError if cert and key public keys do not match."""
+    from cryptography import x509
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+    cert = x509.load_pem_x509_certificate(cert_content, default_backend())
+    key = load_pem_private_key(key_content, password=None)
+
+    if cert.public_key().public_numbers() != key.public_key().public_numbers():
+        raise ValueError("Certificate and private key do not match.")

--- a/apps/certificates/migrations/0001_acme_config.py
+++ b/apps/certificates/migrations/0001_acme_config.py
@@ -1,0 +1,126 @@
+import django.db.models.deletion
+import encrypted_model_fields.fields
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name="AcmeConfig",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("is_enabled", models.BooleanField(default=False)),
+                (
+                    "provider",
+                    models.CharField(
+                        choices=[
+                            ("letsencrypt", "Let's Encrypt"),
+                            ("letsencrypt_staging", "Let's Encrypt (Staging)"),
+                            ("custom", "Custom / Internal CA"),
+                        ],
+                        default="letsencrypt",
+                        max_length=30,
+                    ),
+                ),
+                (
+                    "directory_url",
+                    models.CharField(
+                        default="https://acme-v02.api.letsencrypt.org/directory",
+                        help_text="ACME directory URL for the certificate authority.",
+                        max_length=500,
+                    ),
+                ),
+                (
+                    "domain",
+                    models.CharField(
+                        blank=True,
+                        help_text="Fully qualified domain name for the certificate.",
+                        max_length=255,
+                    ),
+                ),
+                (
+                    "email",
+                    models.EmailField(
+                        blank=True,
+                        help_text="Contact email for the ACME account. Required by Let's Encrypt.",
+                        max_length=254,
+                    ),
+                ),
+                (
+                    "challenge_type",
+                    models.CharField(
+                        choices=[("http-01", "HTTP-01"), ("dns-01", "DNS-01")],
+                        default="http-01",
+                        max_length=10,
+                    ),
+                ),
+                (
+                    "acme_account_key_pem",
+                    encrypted_model_fields.fields.EncryptedCharField(
+                        blank=True, max_length=2000,
+                    ),
+                ),
+                ("acme_account_url", models.CharField(blank=True, max_length=500)),
+                (
+                    "ca_bundle",
+                    models.TextField(
+                        blank=True,
+                        help_text="PEM-encoded CA certificate for verifying the ACME server's TLS.",
+                    ),
+                ),
+                (
+                    "skip_tls_verify",
+                    models.BooleanField(
+                        default=False,
+                        help_text="Disable TLS verification for the ACME server. Testing only.",
+                    ),
+                ),
+                ("dns_txt_value", models.CharField(blank=True, max_length=500)),
+                ("dns_challenge_pending", models.BooleanField(default=False)),
+                ("last_renewed_at", models.DateTimeField(blank=True, null=True)),
+                ("last_renewal_error", models.TextField(blank=True)),
+                ("notify_30_sent", models.BooleanField(default=False)),
+                ("notify_14_sent", models.BooleanField(default=False)),
+                ("notify_7_sent", models.BooleanField(default=False)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "verbose_name": "ACME Configuration",
+            },
+        ),
+        migrations.CreateModel(
+            name="AcmeLog",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("event", models.CharField(max_length=50)),
+                ("detail", models.TextField(blank=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                "ordering": ["-created_at"],
+            },
+        ),
+    ]

--- a/apps/certificates/migrations/0002_acme_issuing_status.py
+++ b/apps/certificates/migrations/0002_acme_issuing_status.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("certificates", "0001_acme_config"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="acmeconfig",
+            name="issuing_in_progress",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="acmeconfig",
+            name="issuing_stage",
+            field=models.CharField(blank=True, max_length=100),
+        ),
+    ]

--- a/apps/certificates/migrations/0003_acme_pending_order.py
+++ b/apps/certificates/migrations/0003_acme_pending_order.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("certificates", "0002_acme_issuing_status"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="acmeconfig",
+            name="pending_order_url",
+            field=models.CharField(blank=True, max_length=500),
+        ),
+        migrations.AddField(
+            model_name="acmeconfig",
+            name="pending_challenge_url",
+            field=models.CharField(blank=True, max_length=500),
+        ),
+    ]

--- a/apps/certificates/migrations/0004_acme_dns_provider.py
+++ b/apps/certificates/migrations/0004_acme_dns_provider.py
@@ -1,0 +1,54 @@
+import encrypted_model_fields.fields
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("certificates", "0003_acme_pending_order"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="acmeconfig",
+            name="dns_provider",
+            field=models.CharField(
+                choices=[
+                    ("none", "None (HTTP-01 only)"),
+                    ("cloudflare", "Cloudflare"),
+                    ("route53", "AWS Route 53"),
+                    ("azure", "Azure DNS"),
+                    ("godaddy", "GoDaddy"),
+                    ("digitalocean", "DigitalOcean"),
+                    ("manual", "Manual (email TXT record to admins)"),
+                ],
+                default="none",
+                max_length=20,
+            ),
+        ),
+        migrations.AddField(
+            model_name="acmeconfig",
+            name="dns_api_token",
+            field=encrypted_model_fields.fields.EncryptedCharField(
+                blank=True, max_length=500,
+                help_text="API token for the DNS provider.",
+            ),
+        ),
+        migrations.AddField(
+            model_name="acmeconfig",
+            name="dns_api_secret",
+            field=encrypted_model_fields.fields.EncryptedCharField(
+                blank=True, max_length=500,
+                help_text="API secret (Route 53 secret key, GoDaddy API secret).",
+            ),
+        ),
+        migrations.AddField(
+            model_name="acmeconfig",
+            name="dns_zone_id",
+            field=models.CharField(
+                blank=True, max_length=255,
+                help_text="Zone ID or hosted zone ID (Cloudflare, Route 53, Azure).",
+            ),
+        ),
+    ]

--- a/apps/certificates/migrations/0005_acme_ip_sans.py
+++ b/apps/certificates/migrations/0005_acme_ip_sans.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("certificates", "0004_acme_dns_provider"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="acmeconfig",
+            name="ip_sans",
+            field=models.CharField(
+                blank=True, max_length=500,
+                help_text="Comma-separated IP addresses to include as SANs.",
+            ),
+        ),
+    ]

--- a/apps/certificates/models.py
+++ b/apps/certificates/models.py
@@ -1,0 +1,133 @@
+import logging
+
+from django.db import models
+from encrypted_model_fields.fields import EncryptedCharField
+
+logger = logging.getLogger(__name__)
+
+PROVIDER_LETSENCRYPT = "letsencrypt"
+PROVIDER_LETSENCRYPT_STAGING = "letsencrypt_staging"
+PROVIDER_CUSTOM = "custom"
+
+PROVIDER_CHOICES = [
+    (PROVIDER_LETSENCRYPT, "Let's Encrypt"),
+    (PROVIDER_LETSENCRYPT_STAGING, "Let's Encrypt (Staging)"),
+    (PROVIDER_CUSTOM, "Custom / Internal CA"),
+]
+
+CHALLENGE_HTTP01 = "http-01"
+CHALLENGE_DNS01 = "dns-01"
+
+CHALLENGE_CHOICES = [
+    (CHALLENGE_HTTP01, "HTTP-01"),
+    (CHALLENGE_DNS01, "DNS-01"),
+]
+
+DIRECTORY_URLS = {
+    PROVIDER_LETSENCRYPT: "https://acme-v02.api.letsencrypt.org/directory",
+    PROVIDER_LETSENCRYPT_STAGING: "https://acme-staging-v02.api.letsencrypt.org/directory",
+}
+
+
+class AcmeConfig(models.Model):
+    """Singleton ACME certificate automation configuration."""
+
+    is_enabled = models.BooleanField(default=False)
+
+    provider = models.CharField(
+        max_length=30,
+        choices=PROVIDER_CHOICES,
+        default=PROVIDER_LETSENCRYPT,
+    )
+    directory_url = models.CharField(
+        max_length=500,
+        default=DIRECTORY_URLS[PROVIDER_LETSENCRYPT],
+        help_text="ACME directory URL for the certificate authority.",
+    )
+    domain = models.CharField(
+        max_length=255,
+        blank=True,
+        help_text="Fully qualified domain name for the certificate.",
+    )
+    email = models.EmailField(
+        blank=True,
+        help_text="Contact email for the ACME account. Required by Let's Encrypt.",
+    )
+    challenge_type = models.CharField(
+        max_length=10,
+        choices=CHALLENGE_CHOICES,
+        default=CHALLENGE_HTTP01,
+    )
+
+    # ACME account credentials (encrypted at rest)
+    acme_account_key_pem = EncryptedCharField(max_length=2000, blank=True)
+    acme_account_url = models.CharField(max_length=500, blank=True)
+
+    # Internal CA TLS settings
+    ca_bundle = models.TextField(
+        blank=True,
+        help_text="PEM-encoded CA certificate for verifying the ACME server's TLS.",
+    )
+    skip_tls_verify = models.BooleanField(
+        default=False,
+        help_text="Disable TLS verification for the ACME server. Testing only.",
+    )
+
+    # DNS-01 transient state
+    dns_txt_value = models.CharField(max_length=500, blank=True)
+    dns_challenge_pending = models.BooleanField(default=False)
+
+    # Renewal tracking
+    last_renewed_at = models.DateTimeField(null=True, blank=True)
+    last_renewal_error = models.TextField(blank=True)
+
+    # Notification flags (reset on successful renewal)
+    notify_30_sent = models.BooleanField(default=False)
+    notify_14_sent = models.BooleanField(default=False)
+    notify_7_sent = models.BooleanField(default=False)
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "ACME Configuration"
+
+    def __str__(self):
+        return f"AcmeConfig(provider={self.provider}, domain={self.domain})"
+
+    @classmethod
+    def get_config(cls):
+        """Return the singleton instance, creating it if needed."""
+        obj, _created = cls.objects.get_or_create(pk=1)
+        return obj
+
+    def get_verify(self):
+        """Return the `verify` parameter for requests calls.
+
+        Returns False (skip), a temp file path (custom CA bundle), or True (default).
+        """
+        if self.skip_tls_verify:
+            return False
+        if self.ca_bundle.strip():
+            return self.ca_bundle.strip()
+        return True
+
+
+class AcmeLog(models.Model):
+    """Audit trail for ACME certificate operations."""
+
+    event = models.CharField(max_length=50)
+    detail = models.TextField(blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        return f"AcmeLog({self.event}, {self.created_at})"
+
+    @classmethod
+    def log(cls, event, detail=""):
+        """Create a log entry."""
+        logger.info("ACME %s: %s", event, detail)
+        return cls.objects.create(event=event, detail=detail)

--- a/apps/certificates/models.py
+++ b/apps/certificates/models.py
@@ -67,6 +67,11 @@ class AcmeConfig(models.Model):
         blank=True,
         help_text="Fully qualified domain name for the certificate.",
     )
+    ip_sans = models.CharField(
+        max_length=500,
+        blank=True,
+        help_text="Comma-separated IP addresses to include as SANs.",
+    )
     email = models.EmailField(
         blank=True,
         help_text="Contact email for the ACME account. Required by Let's Encrypt.",

--- a/apps/certificates/models.py
+++ b/apps/certificates/models.py
@@ -77,6 +77,10 @@ class AcmeConfig(models.Model):
     dns_txt_value = models.CharField(max_length=500, blank=True)
     dns_challenge_pending = models.BooleanField(default=False)
 
+    # Issuance tracking
+    issuing_in_progress = models.BooleanField(default=False)
+    issuing_stage = models.CharField(max_length=100, blank=True)
+
     # Renewal tracking
     last_renewed_at = models.DateTimeField(null=True, blank=True)
     last_renewal_error = models.TextField(blank=True)

--- a/apps/certificates/models.py
+++ b/apps/certificates/models.py
@@ -77,6 +77,10 @@ class AcmeConfig(models.Model):
     dns_txt_value = models.CharField(max_length=500, blank=True)
     dns_challenge_pending = models.BooleanField(default=False)
 
+    # Saved order/challenge state (so the task can resume the view's order)
+    pending_order_url = models.CharField(max_length=500, blank=True)
+    pending_challenge_url = models.CharField(max_length=500, blank=True)
+
     # Issuance tracking
     issuing_in_progress = models.BooleanField(default=False)
     issuing_stage = models.CharField(max_length=100, blank=True)

--- a/apps/certificates/models.py
+++ b/apps/certificates/models.py
@@ -23,6 +23,24 @@ CHALLENGE_CHOICES = [
     (CHALLENGE_DNS01, "DNS-01"),
 ]
 
+DNS_PROVIDER_NONE = "none"
+DNS_PROVIDER_CLOUDFLARE = "cloudflare"
+DNS_PROVIDER_ROUTE53 = "route53"
+DNS_PROVIDER_AZURE = "azure"
+DNS_PROVIDER_GODADDY = "godaddy"
+DNS_PROVIDER_DIGITALOCEAN = "digitalocean"
+DNS_PROVIDER_MANUAL = "manual"
+
+DNS_PROVIDER_CHOICES = [
+    (DNS_PROVIDER_NONE, "None (HTTP-01 only)"),
+    (DNS_PROVIDER_CLOUDFLARE, "Cloudflare"),
+    (DNS_PROVIDER_ROUTE53, "AWS Route 53"),
+    (DNS_PROVIDER_AZURE, "Azure DNS"),
+    (DNS_PROVIDER_GODADDY, "GoDaddy"),
+    (DNS_PROVIDER_DIGITALOCEAN, "DigitalOcean"),
+    (DNS_PROVIDER_MANUAL, "Manual (email TXT record to admins)"),
+]
+
 DIRECTORY_URLS = {
     PROVIDER_LETSENCRYPT: "https://acme-v02.api.letsencrypt.org/directory",
     PROVIDER_LETSENCRYPT_STAGING: "https://acme-staging-v02.api.letsencrypt.org/directory",
@@ -57,6 +75,25 @@ class AcmeConfig(models.Model):
         max_length=10,
         choices=CHALLENGE_CHOICES,
         default=CHALLENGE_HTTP01,
+    )
+
+    # DNS provider for automated DNS-01 challenges
+    dns_provider = models.CharField(
+        max_length=20,
+        choices=DNS_PROVIDER_CHOICES,
+        default=DNS_PROVIDER_NONE,
+    )
+    dns_api_token = EncryptedCharField(
+        max_length=500, blank=True,
+        help_text="API token for the DNS provider.",
+    )
+    dns_api_secret = EncryptedCharField(
+        max_length=500, blank=True,
+        help_text="API secret (Route 53 secret key, GoDaddy API secret).",
+    )
+    dns_zone_id = models.CharField(
+        max_length=255, blank=True,
+        help_text="Zone ID or hosted zone ID (Cloudflare, Route 53, Azure).",
     )
 
     # ACME account credentials (encrypted at rest)

--- a/apps/certificates/tasks.py
+++ b/apps/certificates/tasks.py
@@ -331,31 +331,123 @@ def issue_acme_certificate(self):
 
 @shared_task(name="certificates.check_cert_expiry")
 def check_cert_expiry():
-    """Daily task: check certificate expiry, auto-renew or send alerts."""
-    from apps.certificates.models import AcmeConfig
+    """Daily task: check certificate expiry, auto-renew or send alerts.
+
+    Renewal triggers at the halfway point of the certificate's validity
+    period (e.g. a 90-day cert renews at 45 days remaining).
+    """
+    from apps.certificates.models import AcmeConfig, AcmeLog
 
     cert_info = _get_cert_info()
-    if not cert_info or "not_after" not in cert_info:
+    if not cert_info or "not_after" not in cert_info or "not_before" not in cert_info:
         return
 
-    days_remaining = (cert_info["not_after"] - timezone.now()).days
-    logger.info("Certificate expires in %d days", days_remaining)
+    now = timezone.now()
+    days_remaining = (cert_info["not_after"] - now).days
+    total_validity = (cert_info["not_after"] - cert_info["not_before"]).days
+    renewal_threshold = max(total_validity // 2, 7)  # half validity, minimum 7 days
+
+    logger.info(
+        "Certificate: %d days remaining, %d day validity, renew at %d days",
+        days_remaining, total_validity, renewal_threshold,
+    )
 
     config = AcmeConfig.get_config()
 
-    # Auto-renew if ACME is enabled and HTTP-01
-    if config.is_enabled and days_remaining <= 30:
+    if config.is_enabled and days_remaining <= renewal_threshold:
         if config.challenge_type == "http-01":
             logger.info("Auto-renewing certificate via ACME (HTTP-01)")
+            config.issuing_in_progress = True
+            config.issuing_stage = "Auto-renewal starting..."
+            config.save(update_fields=["issuing_in_progress", "issuing_stage", "updated_at"])
             issue_acme_certificate.delay()
+            AcmeLog.log("renewal_triggered", f"Auto-renewal (HTTP-01), {days_remaining} days remaining")
             return
         else:
-            logger.info(
-                "Certificate expiring but DNS-01 requires manual renewal — sending alerts"
-            )
+            # DNS-01: auto-trigger the order and email the TXT value
+            logger.info("Auto-triggering DNS-01 renewal, emailing TXT value to admins")
+            _auto_trigger_dns01_renewal(config, days_remaining)
+            return
 
     # Send email alerts at thresholds
     _send_expiry_alerts(config, days_remaining)
+
+
+def _auto_trigger_dns01_renewal(config, days_remaining):
+    """Create an ACME order for DNS-01 and email the TXT value to staff."""
+    from apps.certificates.models import AcmeLog
+
+    verify = _get_verify(config)
+    try:
+        key_pem = config.acme_account_key_pem
+        account_url = config.acme_account_url
+
+        order_url, order = acme.create_order(
+            key_pem, account_url, config.directory_url, config.domain,
+            verify=verify,
+        )
+
+        if order.get("status") in ("ready", "valid"):
+            # Internal CA skipping challenges — just issue directly
+            config.issuing_in_progress = True
+            config.issuing_stage = "Auto-renewal starting..."
+            config.save(update_fields=["issuing_in_progress", "issuing_stage", "updated_at"])
+            issue_acme_certificate.delay()
+            return
+
+        for auth_url in order.get("authorizations", []):
+            auth = acme.get_authorization(key_pem, account_url, auth_url, verify=verify)
+            if auth.get("status") == "valid":
+                continue
+
+            challenge = acme.get_dns01_challenge(auth)
+            if not challenge:
+                continue
+
+            txt_value = acme.compute_dns01_txt_value(key_pem, challenge["token"])
+
+            config.dns_txt_value = txt_value
+            config.dns_challenge_pending = True
+            config.pending_order_url = order_url
+            config.pending_challenge_url = challenge["url"]
+            config.save(update_fields=[
+                "dns_txt_value", "dns_challenge_pending",
+                "pending_order_url", "pending_challenge_url", "updated_at",
+            ])
+
+            AcmeLog.log("renewal_triggered", f"Auto-renewal (DNS-01), {days_remaining} days remaining")
+
+            # Email the TXT record to all staff
+            staff_emails = list(
+                User.objects.filter(is_staff=True)
+                .exclude(email="")
+                .values_list("email", flat=True)
+            )
+            if staff_emails:
+                send_mail(
+                    f"[ProxMigrate] DNS record needed for certificate renewal",
+                    f"ProxMigrate needs to renew its TLS certificate "
+                    f"({days_remaining} days remaining).\n\n"
+                    f"Please create or update this DNS TXT record:\n\n"
+                    f"  Name:  _acme-challenge.{config.domain}\n"
+                    f"  Value: {txt_value}\n\n"
+                    f"Then log in to ProxMigrate and click "
+                    f"'I've Created the DNS Record' on the Certificates page.\n\n"
+                    f"— ProxMigrate",
+                    None,
+                    staff_emails,
+                    fail_silently=True,
+                )
+                logger.info("Sent DNS-01 renewal TXT value to %d staff users", len(staff_emails))
+
+            return
+
+    except Exception as exc:
+        logger.error("Auto DNS-01 renewal trigger failed: %s", exc)
+        from apps.certificates.models import AcmeLog
+        AcmeLog.log("renewal_failed", f"Auto DNS-01 trigger: {exc}")
+    finally:
+        _cleanup_ca_bundle(verify)
 
 
 def _send_expiry_alerts(config, days_remaining):

--- a/apps/certificates/tasks.py
+++ b/apps/certificates/tasks.py
@@ -143,6 +143,7 @@ def issue_acme_certificate(self):
         config.save(update_fields=["issuing_in_progress", "issuing_stage", "updated_at"])
 
     verify = _get_verify(config)
+    ip_sans = [ip.strip() for ip in config.ip_sans.split(",") if ip.strip()] if config.ip_sans else []
     token = None
 
     try:
@@ -205,7 +206,7 @@ def issue_acme_certificate(self):
             logger.info("Creating ACME order for %s", config.domain)
             order_url, order = acme.create_order(
                 key_pem, account_url, config.directory_url, config.domain,
-                verify=verify,
+                ip_sans=ip_sans, verify=verify,
             )
             AcmeLog.log("order_created", f"Order for {config.domain}")
 
@@ -295,7 +296,7 @@ def issue_acme_certificate(self):
         # Step 4: Generate CSR and finalize
         _set_stage("Generating CSR and finalizing order...")
         logger.info("Finalizing ACME order for %s", config.domain)
-        cert_key_pem, csr_der = acme.generate_csr(config.domain)
+        cert_key_pem, csr_der = acme.generate_csr(config.domain, ip_sans=ip_sans)
 
         finalize_url = order.get("finalize")
         if not finalize_url:
@@ -452,9 +453,10 @@ def _auto_trigger_dns01_renewal(config, days_remaining):
         key_pem = config.acme_account_key_pem
         account_url = config.acme_account_url
 
+        ip_sans = [ip.strip() for ip in config.ip_sans.split(",") if ip.strip()] if config.ip_sans else []
         order_url, order = acme.create_order(
             key_pem, account_url, config.directory_url, config.domain,
-            verify=verify,
+            ip_sans=ip_sans, verify=verify,
         )
 
         if order.get("status") in ("ready", "valid"):

--- a/apps/certificates/tasks.py
+++ b/apps/certificates/tasks.py
@@ -86,8 +86,13 @@ def _cleanup_challenge(token=None):
 
 
 def _get_server_ips():
-    """Auto-discover this server's non-loopback IPv4 addresses."""
-    import socket
+    """Auto-discover this server's primary IPv4 addresses.
+
+    Only includes RFC 1918 private IPs (192.168.x.x, 10.x.x.x, 172.16-31.x.x)
+    and public IPs. Excludes loopback, link-local, VPN/tunnel IPs (100.64-127.x.x
+    carrier-grade NAT range commonly used by Tailscale, ZeroTier, etc.).
+    """
+    import ipaddress
     import subprocess
 
     ips = []
@@ -98,21 +103,21 @@ def _get_server_ips():
         )
         if result.returncode == 0:
             for addr in result.stdout.strip().split():
-                # Only include IPv4, skip loopback and link-local
-                if ":" not in addr and not addr.startswith("127.") and not addr.startswith("169.254."):
+                if ":" in addr:
+                    continue  # skip IPv6
+                try:
+                    ip = ipaddress.ip_address(addr)
+                    # Skip loopback, link-local, and carrier-grade NAT (VPN tunnels)
+                    if ip.is_loopback or ip.is_link_local:
+                        continue
+                    # Skip 100.64.0.0/10 — CGNAT range used by Tailscale, ZeroTier
+                    if ipaddress.ip_address("100.64.0.0") <= ip <= ipaddress.ip_address("100.127.255.255"):
+                        continue
                     ips.append(addr)
+                except ValueError:
+                    continue
     except Exception:
         pass
-
-    if not ips:
-        # Fallback: get the IP from the default route
-        try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            s.connect(("8.8.8.8", 80))
-            ips.append(s.getsockname()[0])
-            s.close()
-        except Exception:
-            pass
 
     return ips
 

--- a/apps/certificates/tasks.py
+++ b/apps/certificates/tasks.py
@@ -147,10 +147,18 @@ def issue_acme_certificate(self):
     if not config.domain:
         raise AcmeError("No domain configured for ACME")
 
+    def _set_stage(stage):
+        config.refresh_from_db()
+        config.issuing_in_progress = True
+        config.issuing_stage = stage
+        config.save(update_fields=["issuing_in_progress", "issuing_stage", "updated_at"])
+
     verify = _get_verify(config)
     token = None
 
     try:
+        _set_stage("Registering account...")
+
         # Step 1: Account registration
         if not config.acme_account_key_pem:
             logger.info("Generating ACME account key")
@@ -174,6 +182,7 @@ def issue_acme_certificate(self):
         account_url = config.acme_account_url
 
         # Step 2: Create order
+        _set_stage("Creating certificate order...")
         logger.info("Creating ACME order for %s", config.domain)
         order_url, order = acme.create_order(
             key_pem, account_url, config.directory_url, config.domain,
@@ -182,6 +191,7 @@ def issue_acme_certificate(self):
         AcmeLog.log("order_created", f"Order for {config.domain}")
 
         # Step 3: Handle authorizations (if needed)
+        _set_stage("Validating domain ownership...")
         if order.get("status") not in ("ready", "valid"):
             for auth_url in order.get("authorizations", []):
                 auth = acme.get_authorization(
@@ -269,11 +279,13 @@ def issue_acme_certificate(self):
                     AcmeLog.log("challenge_completed", "DNS-01 challenge submitted")
 
             # Poll order until ready
+            _set_stage("Waiting for CA to validate challenge...")
             order = acme.poll_order(
                 key_pem, account_url, order_url, verify=verify,
             )
 
         # Step 4: Generate CSR and finalize
+        _set_stage("Generating CSR and finalizing order...")
         logger.info("Finalizing ACME order for %s", config.domain)
         cert_key_pem, csr_der = acme.generate_csr(config.domain)
 
@@ -292,6 +304,7 @@ def issue_acme_certificate(self):
             )
 
         # Step 5: Download and install certificate
+        _set_stage("Downloading and installing certificate...")
         cert_url = order.get("certificate")
         if not cert_url:
             raise AcmeError("No certificate URL in finalized order")
@@ -306,13 +319,16 @@ def issue_acme_certificate(self):
 
         # Step 6: Update config
         config.is_enabled = True
+        config.issuing_in_progress = False
+        config.issuing_stage = ""
         config.last_renewed_at = timezone.now()
         config.last_renewal_error = ""
         config.notify_30_sent = False
         config.notify_14_sent = False
         config.notify_7_sent = False
         config.save(update_fields=[
-            "is_enabled", "last_renewed_at", "last_renewal_error",
+            "is_enabled", "issuing_in_progress", "issuing_stage",
+            "last_renewed_at", "last_renewal_error",
             "notify_30_sent", "notify_14_sent", "notify_7_sent", "updated_at",
         ])
 
@@ -320,8 +336,13 @@ def issue_acme_certificate(self):
 
     except Exception as exc:
         config.refresh_from_db()
+        config.issuing_in_progress = False
+        config.issuing_stage = ""
         config.last_renewal_error = str(exc)
-        config.save(update_fields=["last_renewal_error", "updated_at"])
+        config.save(update_fields=[
+            "issuing_in_progress", "issuing_stage",
+            "last_renewal_error", "updated_at",
+        ])
         AcmeLog.log("renewal_failed", str(exc))
         logger.error("ACME certificate issuance failed: %s", exc)
         raise

--- a/apps/certificates/tasks.py
+++ b/apps/certificates/tasks.py
@@ -85,6 +85,38 @@ def _cleanup_challenge(token=None):
         logger.warning("nginx reload failed during challenge cleanup")
 
 
+def _get_server_ips():
+    """Auto-discover this server's non-loopback IPv4 addresses."""
+    import socket
+    import subprocess
+
+    ips = []
+    try:
+        result = subprocess.run(
+            ["hostname", "-I"],
+            capture_output=True, text=True, shell=False,
+        )
+        if result.returncode == 0:
+            for addr in result.stdout.strip().split():
+                # Only include IPv4, skip loopback and link-local
+                if ":" not in addr and not addr.startswith("127.") and not addr.startswith("169.254."):
+                    ips.append(addr)
+    except Exception:
+        pass
+
+    if not ips:
+        # Fallback: get the IP from the default route
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            s.connect(("8.8.8.8", 80))
+            ips.append(s.getsockname()[0])
+            s.close()
+        except Exception:
+            pass
+
+    return ips
+
+
 def _get_verify(config):
     """Build the requests verify parameter from AcmeConfig."""
     if config.skip_tls_verify:
@@ -144,6 +176,16 @@ def issue_acme_certificate(self):
 
     verify = _get_verify(config)
     ip_sans = [ip.strip() for ip in config.ip_sans.split(",") if ip.strip()] if config.ip_sans else []
+
+    # Auto-discover server IPs for internal CAs
+    if config.provider == "custom":
+        discovered_ips = _get_server_ips()
+        for ip in discovered_ips:
+            if ip not in ip_sans:
+                ip_sans.append(ip)
+        if ip_sans:
+            logger.info("IP SANs for cert: %s", ", ".join(ip_sans))
+
     token = None
 
     try:

--- a/apps/certificates/tasks.py
+++ b/apps/certificates/tasks.py
@@ -1,0 +1,409 @@
+import logging
+import os
+import tempfile
+
+import redis
+from celery import shared_task
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.mail import send_mail
+from django.utils import timezone
+
+from apps.certificates import acme
+from apps.certificates.acme import AcmeError
+
+logger = logging.getLogger(__name__)
+
+CERT_DIR = "/opt/proxmigrate/certs"
+CERT_FILE = os.path.join(CERT_DIR, "proxmigrate.crt")
+KEY_FILE = os.path.join(CERT_DIR, "proxmigrate.key")
+CHALLENGE_DIR = os.path.join(CERT_DIR, "acme-challenge")
+ACME_NGINX_CONF = "/opt/proxmigrate/deploy/acme-challenge.conf"
+
+REDIS_DNS_CONFIRM_KEY = "acme:dns_confirmed"
+DNS_POLL_INTERVAL = 10
+DNS_POLL_TIMEOUT = 1800  # 30 minutes
+
+ACME_NGINX_BLOCK = """server {
+    listen 80;
+    server_name _;
+    location /.well-known/acme-challenge/ {
+        alias /opt/proxmigrate/certs/acme-challenge/;
+    }
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+"""
+
+
+def _get_redis():
+    """Return a Redis client using the Celery broker URL."""
+    broker_url = getattr(settings, "CELERY_BROKER_URL", "redis://127.0.0.1:6379/0")
+    return redis.Redis.from_url(broker_url)
+
+
+def _install_cert_and_key(cert_pem, key_pem):
+    """Write certificate and key files to disk."""
+    os.makedirs(CERT_DIR, exist_ok=True)
+    with open(CERT_FILE, "wb") as f:
+        f.write(cert_pem if isinstance(cert_pem, bytes) else cert_pem.encode())
+    with open(KEY_FILE, "wb") as f:
+        f.write(key_pem if isinstance(key_pem, bytes) else key_pem.encode())
+    os.chmod(KEY_FILE, 0o600)
+
+
+def _reload_nginx():
+    """Reload nginx. Raises RuntimeError on failure."""
+    import subprocess
+
+    result = subprocess.run(
+        ["sudo", "nginx", "-s", "reload"],
+        capture_output=True, text=True, shell=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"nginx reload failed: {result.stderr.strip()}")
+
+
+def _test_nginx():
+    """Test nginx config. Returns True if valid."""
+    import subprocess
+
+    result = subprocess.run(
+        ["sudo", "nginx", "-t"],
+        capture_output=True, text=True, shell=False,
+    )
+    return result.returncode == 0
+
+
+def _write_acme_nginx(content):
+    """Write the ACME challenge nginx config file."""
+    with open(ACME_NGINX_CONF, "w") as f:
+        f.write(content)
+
+
+def _cleanup_challenge(token=None):
+    """Remove challenge token file and clear the nginx config."""
+    if token:
+        token_path = os.path.join(CHALLENGE_DIR, token)
+        if os.path.exists(token_path):
+            os.remove(token_path)
+
+    _write_acme_nginx("")
+    try:
+        _reload_nginx()
+    except RuntimeError:
+        logger.warning("nginx reload failed during challenge cleanup")
+
+
+def _get_verify(config):
+    """Build the requests verify parameter from AcmeConfig."""
+    if config.skip_tls_verify:
+        return False
+    if config.ca_bundle.strip():
+        # Write CA bundle to a temp file for requests to use
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".pem", delete=False,
+            dir=CERT_DIR,
+        )
+        tmp.write(config.ca_bundle.strip())
+        tmp.close()
+        return tmp.name
+    return True
+
+
+def _cleanup_ca_bundle(verify):
+    """Remove temporary CA bundle file if one was created."""
+    if isinstance(verify, str) and verify.startswith(CERT_DIR) and verify.endswith(".pem"):
+        try:
+            os.remove(verify)
+        except OSError:
+            pass
+
+
+def _get_cert_info():
+    """Parse the current certificate and return info dict."""
+    from cryptography import x509
+
+    if not os.path.exists(CERT_FILE):
+        return None
+    try:
+        with open(CERT_FILE, "rb") as f:
+            cert = x509.load_pem_x509_certificate(f.read())
+        return {
+            "not_after": cert.not_valid_after_utc,
+            "not_before": cert.not_valid_before_utc,
+        }
+    except Exception:
+        return None
+
+
+@shared_task(bind=True, name="certificates.issue_acme_certificate")
+def issue_acme_certificate(self):
+    """Issue or renew a certificate via ACME protocol."""
+    from apps.certificates.models import AcmeConfig, AcmeLog
+
+    config = AcmeConfig.get_config()
+    if not config.domain:
+        raise AcmeError("No domain configured for ACME")
+
+    verify = _get_verify(config)
+    token = None
+
+    try:
+        # Step 1: Account registration
+        if not config.acme_account_key_pem:
+            logger.info("Generating ACME account key")
+            key_pem = acme.generate_account_key()
+            config.acme_account_key_pem = key_pem.decode("utf-8")
+            config.save(update_fields=["acme_account_key_pem", "updated_at"])
+
+        if not config.acme_account_url:
+            logger.info("Registering ACME account at %s", config.directory_url)
+            account_url = acme.register_account(
+                config.acme_account_key_pem,
+                config.directory_url,
+                email=config.email or None,
+                verify=verify,
+            )
+            config.acme_account_url = account_url
+            config.save(update_fields=["acme_account_url", "updated_at"])
+            AcmeLog.log("account_registered", f"Account: {account_url}")
+
+        key_pem = config.acme_account_key_pem
+        account_url = config.acme_account_url
+
+        # Step 2: Create order
+        logger.info("Creating ACME order for %s", config.domain)
+        order_url, order = acme.create_order(
+            key_pem, account_url, config.directory_url, config.domain,
+            verify=verify,
+        )
+        AcmeLog.log("order_created", f"Order for {config.domain}")
+
+        # Step 3: Handle authorizations (if needed)
+        if order.get("status") not in ("ready", "valid"):
+            for auth_url in order.get("authorizations", []):
+                auth = acme.get_authorization(
+                    key_pem, account_url, auth_url, verify=verify,
+                )
+
+                if auth.get("status") == "valid":
+                    continue
+
+                if config.challenge_type == "http-01":
+                    challenge = acme.get_http01_challenge(auth)
+                    if not challenge:
+                        raise AcmeError("No HTTP-01 challenge available")
+
+                    token = challenge["token"]
+                    key_auth = acme.compute_key_authorization(key_pem, token)
+
+                    # Write challenge token file
+                    os.makedirs(CHALLENGE_DIR, exist_ok=True)
+                    token_path = os.path.join(CHALLENGE_DIR, token)
+                    with open(token_path, "w") as f:
+                        f.write(key_auth)
+
+                    # Enable nginx port 80 block
+                    _write_acme_nginx(ACME_NGINX_BLOCK)
+                    if not _test_nginx():
+                        _cleanup_challenge(token)
+                        raise AcmeError(
+                            "nginx config test failed — port 80 may be in use. "
+                            "Ensure port 80 is available for HTTP-01 challenges."
+                        )
+                    _reload_nginx()
+
+                    # Respond to challenge
+                    acme.respond_to_challenge(
+                        key_pem, account_url, challenge["url"], verify=verify,
+                    )
+                    AcmeLog.log("challenge_completed", "HTTP-01 challenge submitted")
+
+                else:
+                    # DNS-01
+                    challenge = acme.get_dns01_challenge(auth)
+                    if not challenge:
+                        raise AcmeError("No DNS-01 challenge available")
+
+                    txt_value = acme.compute_dns01_txt_value(
+                        key_pem, challenge["token"],
+                    )
+                    config.dns_txt_value = txt_value
+                    config.dns_challenge_pending = True
+                    config.save(update_fields=[
+                        "dns_txt_value", "dns_challenge_pending", "updated_at",
+                    ])
+
+                    # Wait for user to confirm DNS record creation
+                    r = _get_redis()
+                    r.delete(REDIS_DNS_CONFIRM_KEY)
+                    logger.info(
+                        "Waiting for DNS-01 TXT record confirmation. "
+                        "Record: _acme-challenge.%s = %s",
+                        config.domain, txt_value,
+                    )
+
+                    import time
+
+                    deadline = time.time() + DNS_POLL_TIMEOUT
+                    while time.time() < deadline:
+                        if r.get(REDIS_DNS_CONFIRM_KEY):
+                            break
+                        time.sleep(DNS_POLL_INTERVAL)
+                    else:
+                        config.dns_challenge_pending = False
+                        config.save(update_fields=["dns_challenge_pending", "updated_at"])
+                        raise AcmeError(
+                            "DNS-01 confirmation timed out after 30 minutes"
+                        )
+
+                    config.dns_challenge_pending = False
+                    config.save(update_fields=["dns_challenge_pending", "updated_at"])
+                    r.delete(REDIS_DNS_CONFIRM_KEY)
+
+                    acme.respond_to_challenge(
+                        key_pem, account_url, challenge["url"], verify=verify,
+                    )
+                    AcmeLog.log("challenge_completed", "DNS-01 challenge submitted")
+
+            # Poll order until ready
+            order = acme.poll_order(
+                key_pem, account_url, order_url, verify=verify,
+            )
+
+        # Step 4: Generate CSR and finalize
+        logger.info("Finalizing ACME order for %s", config.domain)
+        cert_key_pem, csr_der = acme.generate_csr(config.domain)
+
+        finalize_url = order.get("finalize")
+        if not finalize_url:
+            raise AcmeError("No finalize URL in order")
+
+        order = acme.finalize_order(
+            key_pem, account_url, finalize_url, csr_der, verify=verify,
+        )
+
+        # Poll again if needed after finalization
+        if order.get("status") != "valid":
+            order = acme.poll_order(
+                key_pem, account_url, order_url, verify=verify,
+            )
+
+        # Step 5: Download and install certificate
+        cert_url = order.get("certificate")
+        if not cert_url:
+            raise AcmeError("No certificate URL in finalized order")
+
+        cert_pem = acme.download_certificate(
+            key_pem, account_url, cert_url, verify=verify,
+        )
+
+        _install_cert_and_key(cert_pem, cert_key_pem)
+        _reload_nginx()
+        logger.info("ACME certificate installed for %s", config.domain)
+
+        # Step 6: Update config
+        config.is_enabled = True
+        config.last_renewed_at = timezone.now()
+        config.last_renewal_error = ""
+        config.notify_30_sent = False
+        config.notify_14_sent = False
+        config.notify_7_sent = False
+        config.save(update_fields=[
+            "is_enabled", "last_renewed_at", "last_renewal_error",
+            "notify_30_sent", "notify_14_sent", "notify_7_sent", "updated_at",
+        ])
+
+        AcmeLog.log("cert_issued", f"Certificate issued for {config.domain}")
+
+    except Exception as exc:
+        config.refresh_from_db()
+        config.last_renewal_error = str(exc)
+        config.save(update_fields=["last_renewal_error", "updated_at"])
+        AcmeLog.log("renewal_failed", str(exc))
+        logger.error("ACME certificate issuance failed: %s", exc)
+        raise
+
+    finally:
+        _cleanup_challenge(token)
+        _cleanup_ca_bundle(verify)
+
+
+@shared_task(name="certificates.check_cert_expiry")
+def check_cert_expiry():
+    """Daily task: check certificate expiry, auto-renew or send alerts."""
+    from apps.certificates.models import AcmeConfig
+
+    cert_info = _get_cert_info()
+    if not cert_info or "not_after" not in cert_info:
+        return
+
+    days_remaining = (cert_info["not_after"] - timezone.now()).days
+    logger.info("Certificate expires in %d days", days_remaining)
+
+    config = AcmeConfig.get_config()
+
+    # Auto-renew if ACME is enabled and HTTP-01
+    if config.is_enabled and days_remaining <= 30:
+        if config.challenge_type == "http-01":
+            logger.info("Auto-renewing certificate via ACME (HTTP-01)")
+            issue_acme_certificate.delay()
+            return
+        else:
+            logger.info(
+                "Certificate expiring but DNS-01 requires manual renewal — sending alerts"
+            )
+
+    # Send email alerts at thresholds
+    _send_expiry_alerts(config, days_remaining)
+
+
+def _send_expiry_alerts(config, days_remaining):
+    """Send email alerts at 30/14/7 day thresholds."""
+    thresholds = [
+        (30, "notify_30_sent"),
+        (14, "notify_14_sent"),
+        (7, "notify_7_sent"),
+    ]
+
+    staff_emails = list(
+        User.objects.filter(is_staff=True)
+        .exclude(email="")
+        .values_list("email", flat=True)
+    )
+    if not staff_emails:
+        return
+
+    for days_threshold, flag_field in thresholds:
+        if days_remaining <= days_threshold and not getattr(config, flag_field):
+            urgency = "URGENT: " if days_threshold == 7 else ""
+            subject = (
+                f"[ProxMigrate] {urgency}TLS certificate expires "
+                f"in {days_remaining} days"
+            )
+            body = (
+                f"The TLS certificate for ProxMigrate expires in "
+                f"{days_remaining} days.\n\n"
+                f"Please log in to ProxMigrate and visit Settings > "
+                f"Certificates to renew.\n\n"
+                f"— ProxMigrate"
+            )
+
+            try:
+                send_mail(
+                    subject,
+                    body,
+                    None,  # uses DEFAULT_FROM_EMAIL
+                    staff_emails,
+                    fail_silently=True,
+                )
+                setattr(config, flag_field, True)
+                config.save(update_fields=[flag_field, "updated_at"])
+                logger.info("Sent %d-day expiry alert to %d staff users",
+                            days_threshold, len(staff_emails))
+            except Exception as exc:
+                logger.error("Failed to send expiry alert: %s", exc)
+
+            break  # Only send the most relevant threshold

--- a/apps/certificates/tasks.py
+++ b/apps/certificates/tasks.py
@@ -322,6 +322,29 @@ def issue_acme_certificate(self):
         )
 
         _install_cert_and_key(cert_pem, cert_key_pem)
+
+        # Update config BEFORE reloading nginx so the HTMX poll can
+        # fetch the success state before the connection resets
+        config.is_enabled = True
+        config.issuing_in_progress = False
+        config.issuing_stage = "Certificate installed. Reloading web server..."
+        config.last_renewed_at = timezone.now()
+        config.last_renewal_error = ""
+        config.notify_30_sent = False
+        config.notify_14_sent = False
+        config.notify_7_sent = False
+        config.save(update_fields=[
+            "is_enabled", "issuing_in_progress", "issuing_stage",
+            "last_renewed_at", "last_renewal_error",
+            "notify_30_sent", "notify_14_sent", "notify_7_sent", "updated_at",
+        ])
+        AcmeLog.log("cert_issued", f"Certificate issued for {config.domain}")
+
+        # Brief delay so the browser's next poll picks up the success state
+        # before nginx reloads and resets the HTTPS connection
+        import time
+        time.sleep(5)
+
         _reload_nginx()
         logger.info("ACME certificate installed for %s", config.domain)
 
@@ -340,22 +363,9 @@ def issue_acme_certificate(self):
             except Exception as exc:
                 logger.warning("DNS TXT cleanup failed (non-fatal): %s", exc)
 
-        # Step 6: Update config
-        config.is_enabled = True
-        config.issuing_in_progress = False
+        # Clear the stage text now that nginx has reloaded
         config.issuing_stage = ""
-        config.last_renewed_at = timezone.now()
-        config.last_renewal_error = ""
-        config.notify_30_sent = False
-        config.notify_14_sent = False
-        config.notify_7_sent = False
-        config.save(update_fields=[
-            "is_enabled", "issuing_in_progress", "issuing_stage",
-            "last_renewed_at", "last_renewal_error",
-            "notify_30_sent", "notify_14_sent", "notify_7_sent", "updated_at",
-        ])
-
-        AcmeLog.log("cert_issued", f"Certificate issued for {config.domain}")
+        config.save(update_fields=["issuing_stage", "updated_at"])
 
     except Exception as exc:
         config.refresh_from_db()

--- a/apps/certificates/tasks.py
+++ b/apps/certificates/tasks.py
@@ -170,75 +170,96 @@ def issue_acme_certificate(self):
         key_pem = config.acme_account_key_pem
         account_url = config.acme_account_url
 
-        # Step 2: Create order
-        _set_stage("Creating certificate order...")
-        logger.info("Creating ACME order for %s", config.domain)
-        order_url, order = acme.create_order(
-            key_pem, account_url, config.directory_url, config.domain,
-            verify=verify,
-        )
-        AcmeLog.log("order_created", f"Order for {config.domain}")
+        # Step 2: Create or resume order
+        if config.pending_order_url and config.pending_challenge_url:
+            # DNS-01: resume the order created by the view
+            _set_stage("Responding to DNS-01 challenge...")
+            order_url = config.pending_order_url
+            logger.info("Resuming ACME order for %s (challenge URL: %s)",
+                        config.domain, config.pending_challenge_url)
 
-        # Step 3: Handle authorizations (if needed)
-        _set_stage("Validating domain ownership...")
-        if order.get("status") not in ("ready", "valid"):
-            for auth_url in order.get("authorizations", []):
-                auth = acme.get_authorization(
-                    key_pem, account_url, auth_url, verify=verify,
-                )
+            acme.respond_to_challenge(
+                key_pem, account_url, config.pending_challenge_url,
+                verify=verify,
+            )
+            AcmeLog.log("challenge_completed", "DNS-01 challenge submitted")
 
-                if auth.get("status") == "valid":
-                    continue
-
-                if config.challenge_type == "http-01":
-                    challenge = acme.get_http01_challenge(auth)
-                    if not challenge:
-                        raise AcmeError("No HTTP-01 challenge available")
-
-                    token = challenge["token"]
-                    key_auth = acme.compute_key_authorization(key_pem, token)
-
-                    # Write challenge token file
-                    os.makedirs(CHALLENGE_DIR, exist_ok=True)
-                    token_path = os.path.join(CHALLENGE_DIR, token)
-                    with open(token_path, "w") as f:
-                        f.write(key_auth)
-
-                    # Enable nginx port 80 block
-                    _write_acme_nginx(ACME_NGINX_BLOCK)
-                    if not _test_nginx():
-                        _cleanup_challenge(token)
-                        raise AcmeError(
-                            "nginx config test failed — port 80 may be in use. "
-                            "Ensure port 80 is available for HTTP-01 challenges."
-                        )
-                    _reload_nginx()
-
-                    # Respond to challenge
-                    acme.respond_to_challenge(
-                        key_pem, account_url, challenge["url"], verify=verify,
-                    )
-                    AcmeLog.log("challenge_completed", "HTTP-01 challenge submitted")
-
-                else:
-                    # DNS-01: the view already created the order and showed the
-                    # TXT record to the user. The user confirmed the DNS record
-                    # exists, so we just respond to the challenge now.
-                    challenge = acme.get_dns01_challenge(auth)
-                    if not challenge:
-                        raise AcmeError("No DNS-01 challenge available")
-
-                    _set_stage("Responding to DNS-01 challenge...")
-                    acme.respond_to_challenge(
-                        key_pem, account_url, challenge["url"], verify=verify,
-                    )
-                    AcmeLog.log("challenge_completed", "DNS-01 challenge submitted")
+            # Clear pending state
+            config.pending_order_url = ""
+            config.pending_challenge_url = ""
+            config.dns_txt_value = ""
+            config.save(update_fields=[
+                "pending_order_url", "pending_challenge_url",
+                "dns_txt_value", "updated_at",
+            ])
 
             # Poll order until ready
             _set_stage("Waiting for CA to validate challenge...")
             order = acme.poll_order(
                 key_pem, account_url, order_url, verify=verify,
             )
+
+        else:
+            # HTTP-01 or fresh order: create new order and handle inline
+            _set_stage("Creating certificate order...")
+            logger.info("Creating ACME order for %s", config.domain)
+            order_url, order = acme.create_order(
+                key_pem, account_url, config.directory_url, config.domain,
+                verify=verify,
+            )
+            AcmeLog.log("order_created", f"Order for {config.domain}")
+
+            _set_stage("Validating domain ownership...")
+            if order.get("status") not in ("ready", "valid"):
+                for auth_url in order.get("authorizations", []):
+                    auth = acme.get_authorization(
+                        key_pem, account_url, auth_url, verify=verify,
+                    )
+
+                    if auth.get("status") == "valid":
+                        continue
+
+                    if config.challenge_type == "http-01":
+                        challenge = acme.get_http01_challenge(auth)
+                        if not challenge:
+                            raise AcmeError("No HTTP-01 challenge available")
+
+                        token = challenge["token"]
+                        key_auth = acme.compute_key_authorization(key_pem, token)
+
+                        # Write challenge token file
+                        os.makedirs(CHALLENGE_DIR, exist_ok=True)
+                        token_path = os.path.join(CHALLENGE_DIR, token)
+                        with open(token_path, "w") as f:
+                            f.write(key_auth)
+
+                        # Enable nginx port 80 block
+                        _write_acme_nginx(ACME_NGINX_BLOCK)
+                        if not _test_nginx():
+                            _cleanup_challenge(token)
+                            raise AcmeError(
+                                "nginx config test failed — port 80 may be in use. "
+                                "Ensure port 80 is available for HTTP-01 challenges."
+                            )
+                        _reload_nginx()
+
+                        # Respond to challenge
+                        acme.respond_to_challenge(
+                            key_pem, account_url, challenge["url"], verify=verify,
+                        )
+                        AcmeLog.log("challenge_completed", "HTTP-01 challenge submitted")
+
+                    else:
+                        raise AcmeError(
+                            "DNS-01 challenge requires using the Issue Certificate "
+                            "button first to generate the TXT record."
+                        )
+
+                # Poll order until ready
+                _set_stage("Waiting for CA to validate challenge...")
+                order = acme.poll_order(
+                    key_pem, account_url, order_url, verify=verify,
+                )
 
         # Step 4: Generate CSR and finalize
         _set_stage("Generating CSR and finalizing order...")

--- a/apps/certificates/tasks.py
+++ b/apps/certificates/tasks.py
@@ -2,7 +2,6 @@ import logging
 import os
 import tempfile
 
-import redis
 from celery import shared_task
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -20,10 +19,6 @@ KEY_FILE = os.path.join(CERT_DIR, "proxmigrate.key")
 CHALLENGE_DIR = os.path.join(CERT_DIR, "acme-challenge")
 ACME_NGINX_CONF = "/opt/proxmigrate/deploy/acme-challenge.conf"
 
-REDIS_DNS_CONFIRM_KEY = "acme:dns_confirmed"
-DNS_POLL_INTERVAL = 10
-DNS_POLL_TIMEOUT = 1800  # 30 minutes
-
 ACME_NGINX_BLOCK = """server {
     listen 80;
     server_name _;
@@ -35,12 +30,6 @@ ACME_NGINX_BLOCK = """server {
     }
 }
 """
-
-
-def _get_redis():
-    """Return a Redis client using the Celery broker URL."""
-    broker_url = getattr(settings, "CELERY_BROKER_URL", "redis://127.0.0.1:6379/0")
-    return redis.Redis.from_url(broker_url)
 
 
 def _install_cert_and_key(cert_pem, key_pem):
@@ -232,47 +221,14 @@ def issue_acme_certificate(self):
                     AcmeLog.log("challenge_completed", "HTTP-01 challenge submitted")
 
                 else:
-                    # DNS-01
+                    # DNS-01: the view already created the order and showed the
+                    # TXT record to the user. The user confirmed the DNS record
+                    # exists, so we just respond to the challenge now.
                     challenge = acme.get_dns01_challenge(auth)
                     if not challenge:
                         raise AcmeError("No DNS-01 challenge available")
 
-                    txt_value = acme.compute_dns01_txt_value(
-                        key_pem, challenge["token"],
-                    )
-                    config.dns_txt_value = txt_value
-                    config.dns_challenge_pending = True
-                    config.save(update_fields=[
-                        "dns_txt_value", "dns_challenge_pending", "updated_at",
-                    ])
-
-                    # Wait for user to confirm DNS record creation
-                    r = _get_redis()
-                    r.delete(REDIS_DNS_CONFIRM_KEY)
-                    logger.info(
-                        "Waiting for DNS-01 TXT record confirmation. "
-                        "Record: _acme-challenge.%s = %s",
-                        config.domain, txt_value,
-                    )
-
-                    import time
-
-                    deadline = time.time() + DNS_POLL_TIMEOUT
-                    while time.time() < deadline:
-                        if r.get(REDIS_DNS_CONFIRM_KEY):
-                            break
-                        time.sleep(DNS_POLL_INTERVAL)
-                    else:
-                        config.dns_challenge_pending = False
-                        config.save(update_fields=["dns_challenge_pending", "updated_at"])
-                        raise AcmeError(
-                            "DNS-01 confirmation timed out after 30 minutes"
-                        )
-
-                    config.dns_challenge_pending = False
-                    config.save(update_fields=["dns_challenge_pending", "updated_at"])
-                    r.delete(REDIS_DNS_CONFIRM_KEY)
-
+                    _set_stage("Responding to DNS-01 challenge...")
                     acme.respond_to_challenge(
                         key_pem, account_url, challenge["url"], verify=verify,
                     )

--- a/apps/certificates/tasks.py
+++ b/apps/certificates/tasks.py
@@ -250,9 +250,40 @@ def issue_acme_certificate(self):
                         AcmeLog.log("challenge_completed", "HTTP-01 challenge submitted")
 
                     else:
-                        raise AcmeError(
-                            "DNS-01 challenge requires using the Issue Certificate "
-                            "button first to generate the TXT record."
+                        # DNS-01 with API provider — fully automated
+                        from apps.certificates import dns_providers
+                        from apps.certificates.models import DNS_PROVIDER_MANUAL, DNS_PROVIDER_NONE
+
+                        if config.dns_provider in (DNS_PROVIDER_NONE, DNS_PROVIDER_MANUAL, ""):
+                            raise AcmeError(
+                                "DNS-01 challenge requires a DNS provider API or "
+                                "using the Issue Certificate button to generate "
+                                "the TXT record manually."
+                            )
+
+                        challenge = acme.get_dns01_challenge(auth)
+                        if not challenge:
+                            raise AcmeError("No DNS-01 challenge available")
+
+                        txt_value = acme.compute_dns01_txt_value(
+                            key_pem, challenge["token"],
+                        )
+
+                        _set_stage(f"Creating DNS TXT record via {config.get_dns_provider_display()}...")
+                        dns_providers.create_txt_record(
+                            config.dns_provider,
+                            config.domain,
+                            txt_value,
+                            api_token=config.dns_api_token,
+                            api_secret=config.dns_api_secret,
+                            zone_id=config.dns_zone_id,
+                        )
+                        AcmeLog.log("challenge_completed",
+                                    f"DNS TXT record created via {config.get_dns_provider_display()}")
+
+                        _set_stage("Responding to DNS-01 challenge...")
+                        acme.respond_to_challenge(
+                            key_pem, account_url, challenge["url"], verify=verify,
                         )
 
                 # Poll order until ready
@@ -293,6 +324,21 @@ def issue_acme_certificate(self):
         _install_cert_and_key(cert_pem, cert_key_pem)
         _reload_nginx()
         logger.info("ACME certificate installed for %s", config.domain)
+
+        # Clean up DNS TXT record if we created one via API
+        if config.dns_provider not in ("none", "manual", ""):
+            try:
+                from apps.certificates import dns_providers
+
+                dns_providers.delete_txt_record(
+                    config.dns_provider,
+                    config.domain,
+                    api_token=config.dns_api_token,
+                    api_secret=config.dns_api_secret,
+                    zone_id=config.dns_zone_id,
+                )
+            except Exception as exc:
+                logger.warning("DNS TXT cleanup failed (non-fatal): %s", exc)
 
         # Step 6: Update config
         config.is_enabled = True
@@ -364,10 +410,24 @@ def check_cert_expiry():
             AcmeLog.log("renewal_triggered", f"Auto-renewal (HTTP-01), {days_remaining} days remaining")
             return
         else:
-            # DNS-01: auto-trigger the order and email the TXT value
-            logger.info("Auto-triggering DNS-01 renewal, emailing TXT value to admins")
-            _auto_trigger_dns01_renewal(config, days_remaining)
-            return
+            # DNS-01: if API provider configured, fully automatic. Otherwise email.
+            from apps.certificates.models import DNS_PROVIDER_MANUAL, DNS_PROVIDER_NONE
+
+            if config.dns_provider not in (DNS_PROVIDER_NONE, DNS_PROVIDER_MANUAL, ""):
+                logger.info("Auto-renewing certificate via ACME (DNS-01 with %s API)",
+                            config.dns_provider)
+                config.issuing_in_progress = True
+                config.issuing_stage = "Auto-renewal starting..."
+                config.save(update_fields=["issuing_in_progress", "issuing_stage", "updated_at"])
+                issue_acme_certificate.delay()
+                AcmeLog.log("renewal_triggered",
+                            f"Auto-renewal (DNS-01 via {config.get_dns_provider_display()}), "
+                            f"{days_remaining} days remaining")
+                return
+            else:
+                logger.info("Auto-triggering DNS-01 renewal, emailing TXT value to admins")
+                _auto_trigger_dns01_renewal(config, days_remaining)
+                return
 
     # Send email alerts at thresholds
     _send_expiry_alerts(config, days_remaining)

--- a/apps/certificates/tasks.py
+++ b/apps/certificates/tasks.py
@@ -447,25 +447,28 @@ def check_cert_expiry():
         return
 
     now = timezone.now()
-    days_remaining = (cert_info["not_after"] - now).days
-    total_validity = (cert_info["not_after"] - cert_info["not_before"]).days
-    renewal_threshold = max(total_validity // 2, 7)  # half validity, minimum 7 days
+    remaining_seconds = (cert_info["not_after"] - now).total_seconds()
+    total_seconds = (cert_info["not_after"] - cert_info["not_before"]).total_seconds()
+    remaining_hours = remaining_seconds / 3600
+    total_hours = total_seconds / 3600
+    renewal_threshold_hours = total_hours / 2  # renew at half validity
 
     logger.info(
-        "Certificate: %d days remaining, %d day validity, renew at %d days",
-        days_remaining, total_validity, renewal_threshold,
+        "Certificate: %.1f hours remaining, %.1f hours total validity, "
+        "renew at %.1f hours",
+        remaining_hours, total_hours, renewal_threshold_hours,
     )
 
     config = AcmeConfig.get_config()
 
-    if config.is_enabled and days_remaining <= renewal_threshold:
+    if config.is_enabled and remaining_hours <= renewal_threshold_hours:
         if config.challenge_type == "http-01":
             logger.info("Auto-renewing certificate via ACME (HTTP-01)")
             config.issuing_in_progress = True
             config.issuing_stage = "Auto-renewal starting..."
             config.save(update_fields=["issuing_in_progress", "issuing_stage", "updated_at"])
             issue_acme_certificate.delay()
-            AcmeLog.log("renewal_triggered", f"Auto-renewal (HTTP-01), {days_remaining} days remaining")
+            AcmeLog.log("renewal_triggered", f"Auto-renewal (HTTP-01), {remaining_hours:.0f} hours remaining")
             return
         else:
             # DNS-01: if API provider configured, fully automatic. Otherwise email.
@@ -480,14 +483,15 @@ def check_cert_expiry():
                 issue_acme_certificate.delay()
                 AcmeLog.log("renewal_triggered",
                             f"Auto-renewal (DNS-01 via {config.get_dns_provider_display()}), "
-                            f"{days_remaining} days remaining")
+                            f"{remaining_hours:.0f} hours remaining")
                 return
             else:
                 logger.info("Auto-triggering DNS-01 renewal, emailing TXT value to admins")
-                _auto_trigger_dns01_renewal(config, days_remaining)
+                _auto_trigger_dns01_renewal(config, int(remaining_hours / 24))
                 return
 
     # Send email alerts at thresholds
+    days_remaining = int(remaining_hours / 24)
     _send_expiry_alerts(config, days_remaining)
 
 

--- a/apps/certificates/tasks.py
+++ b/apps/certificates/tasks.py
@@ -164,9 +164,21 @@ def _get_cert_info():
         return None
 
 
-@shared_task(bind=True, name="certificates.issue_acme_certificate")
+@shared_task(
+    bind=True,
+    name="certificates.issue_acme_certificate",
+    autoretry_for=(Exception,),
+    retry_backoff=60,
+    retry_backoff_max=3600,
+    max_retries=5,
+)
 def issue_acme_certificate(self):
-    """Issue or renew a certificate via ACME protocol."""
+    """Issue or renew a certificate via ACME protocol.
+
+    Retries up to 5 times with exponential backoff (1min, 2min, 4min, 8min, 16min)
+    capped at 1 hour. This ensures short-lived certs get renewed even if the
+    first attempt fails (CA unreachable, DNS propagation, network issues).
+    """
     from apps.certificates.models import AcmeConfig, AcmeLog
 
     config = AcmeConfig.get_config()

--- a/apps/certificates/urls.py
+++ b/apps/certificates/urls.py
@@ -10,4 +10,9 @@ urlpatterns = [
     path("upload/", views.upload_own_cert, name="cert_upload"),
     path("generate/", views.generate_self_signed, name="cert_generate"),
     path("change-port/", views.change_port, name="cert_change_port"),
+    path("acme/configure/", views.acme_configure, name="acme_configure"),
+    path("acme/issue/", views.acme_issue, name="acme_issue"),
+    path("acme/status/", views.acme_status, name="acme_status"),
+    path("acme/dns-confirm/", views.acme_dns_confirm, name="acme_dns_confirm"),
+    path("acme/disable/", views.acme_disable, name="acme_disable"),
 ]

--- a/apps/certificates/urls.py
+++ b/apps/certificates/urls.py
@@ -15,4 +15,5 @@ urlpatterns = [
     path("acme/status/", views.acme_status, name="acme_status"),
     path("acme/dns-confirm/", views.acme_dns_confirm, name="acme_dns_confirm"),
     path("acme/disable/", views.acme_disable, name="acme_disable"),
+    path("acme/reset/", views.acme_reset, name="acme_reset"),
 ]

--- a/apps/certificates/views.py
+++ b/apps/certificates/views.py
@@ -4,31 +4,43 @@ import logging
 import os
 import re
 import subprocess
+from functools import wraps
 
+import redis
+from django.conf import settings
 from django.contrib import messages
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.shortcuts import render
 from django.views.decorators.http import require_POST
 
+from apps.certificates.helpers import CERT_DIR
+from apps.certificates.helpers import CERT_FILE
+from apps.certificates.helpers import CSR_KEY_FILE
+from apps.certificates.helpers import ENV_FILE
+from apps.certificates.helpers import KEY_FILE
+from apps.certificates.helpers import PENDING_CSR_FILE
+from apps.certificates.helpers import find_nginx_conf
+from apps.certificates.helpers import get_cert_info
+from apps.certificates.helpers import get_current_port
+from apps.certificates.helpers import get_pending_csr
+from apps.certificates.helpers import install_cert_and_key
+from apps.certificates.helpers import reload_nginx
+from apps.certificates.helpers import validate_cert_key_pair
+from apps.certificates.models import DIRECTORY_URLS
+from apps.certificates.models import AcmeConfig
+from apps.certificates.models import AcmeLog
+
 logger = logging.getLogger(__name__)
 
-CERT_DIR = "/opt/proxmigrate/certs"
-CERT_FILE = os.path.join(CERT_DIR, "proxmigrate.crt")
-KEY_FILE = os.path.join(CERT_DIR, "proxmigrate.key")
-CSR_KEY_FILE = os.path.join(CERT_DIR, "proxmigrate.csr.key")
-PENDING_CSR_FILE = os.path.join(CERT_DIR, "pending.csr")
-ENV_FILE = "/opt/proxmigrate/.env"
+REDIS_DNS_CONFIRM_KEY = "acme:dns_confirmed"
 
-NGINX_CONF_PATHS = [
-    "/etc/nginx/sites-available/proxmigrate",
-    "/etc/nginx/conf.d/proxmigrate.conf",
-]
 
+# ---------------------------------------------------------------------------
+# Decorators
+# ---------------------------------------------------------------------------
 
 def _staff_required(view_func):
-    from functools import wraps
-
     @wraps(view_func)
     def _wrapped(request, *args, **kwargs):
         if not request.user.is_authenticated:
@@ -40,123 +52,38 @@ def _staff_required(view_func):
     return _wrapped
 
 
-def _get_cert_info():
-    """Parse the current certificate and return a rich info dict, or None."""
-    if not os.path.exists(CERT_FILE):
-        return None
-    try:
-        from cryptography import x509
-        from cryptography.hazmat.backends import default_backend
-
-        with open(CERT_FILE, "rb") as f:
-            cert = x509.load_pem_x509_certificate(f.read(), default_backend())
-
-        san_parts = []
-        try:
-            san_ext = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
-            for name in san_ext.value:
-                if isinstance(name, x509.DNSName):
-                    san_parts.append(f"DNS:{name.value}")
-                elif isinstance(name, x509.IPAddress):
-                    san_parts.append(f"IP:{name.value}")
-        except x509.ExtensionNotFound:
-            pass
-
-        return {
-            "subject": cert.subject.rfc4514_string(),
-            "issuer": cert.issuer.rfc4514_string(),
-            "not_before": cert.not_valid_before_utc,
-            "not_after": cert.not_valid_after_utc,
-            "serial": format(cert.serial_number, "X"),
-            "san": ", ".join(san_parts) or "—",
-            "is_self_signed": cert.subject == cert.issuer,
-        }
-    except Exception as exc:
-        logger.warning("_get_cert_info: %s", exc)
-        return {"error": str(exc)}
-
-
-def _get_pending_csr():
-    """Return the pending CSR PEM text, or None."""
-    if not os.path.exists(PENDING_CSR_FILE):
-        return None
-    try:
-        with open(PENDING_CSR_FILE, "rb") as f:
-            return f.read().decode("utf-8")
-    except OSError:
-        return None
-
-
-def _find_nginx_conf():
-    for p in NGINX_CONF_PATHS:
-        if os.path.exists(p):
-            return p
-    return None
-
-
-def _get_current_port():
-    try:
-        if os.path.exists(ENV_FILE):
-            with open(ENV_FILE) as f:
-                for line in f:
-                    m = re.match(r"^WEB_PORT=(\d+)", line.strip())
-                    if m:
-                        return int(m.group(1))
-    except Exception:
-        pass
-    return 8443
-
-
-def _reload_nginx():
-    result = subprocess.run(
-        ["sudo", "nginx", "-s", "reload"],
-        capture_output=True, text=True, shell=False,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"nginx reload failed: {result.stderr.strip()}")
-
-
-def _install_cert_and_key(cert_content, key_content):
-    os.makedirs(CERT_DIR, exist_ok=True)
-    with open(CERT_FILE, "wb") as f:
-        f.write(cert_content)
-    with open(KEY_FILE, "wb") as f:
-        f.write(key_content)
-    os.chmod(KEY_FILE, 0o600)
-
-
-def _validate_cert_key_pair(cert_content, key_content):
-    """Raise ValueError if cert and key public keys do not match."""
-    from cryptography import x509
-    from cryptography.hazmat.backends import default_backend
-    from cryptography.hazmat.primitives.serialization import load_pem_private_key
-
-    cert = x509.load_pem_x509_certificate(cert_content, default_backend())
-    key = load_pem_private_key(key_content, password=None)
-
-    if cert.public_key().public_numbers() != key.public_key().public_numbers():
-        raise ValueError("Certificate and private key do not match.")
-
+# ---------------------------------------------------------------------------
+# Certificate settings (main page)
+# ---------------------------------------------------------------------------
 
 @_staff_required
 def cert_settings(request):
-    cert_info = _get_cert_info()
+    cert_info = get_cert_info()
 
     cert_days_remaining = None
     if cert_info and "not_after" in cert_info:
         delta = cert_info["not_after"] - datetime.datetime.now(datetime.timezone.utc)
         cert_days_remaining = delta.days
 
+    acme_config = AcmeConfig.get_config()
+    acme_logs = AcmeLog.objects.all()[:10]
+
     return render(request, "certificates/settings.html", {
         "cert_info": cert_info,
         "cert_days_remaining": cert_days_remaining,
-        "pending_csr": _get_pending_csr(),
+        "pending_csr": get_pending_csr(),
         "has_csr_key": os.path.exists(CSR_KEY_FILE),
-        "current_port": _get_current_port(),
+        "current_port": get_current_port(),
         "cert_file": CERT_FILE,
         "key_file": KEY_FILE,
+        "acme": acme_config,
+        "acme_logs": acme_logs,
     })
 
+
+# ---------------------------------------------------------------------------
+# CSR generation
+# ---------------------------------------------------------------------------
 
 @_staff_required
 @require_POST
@@ -174,7 +101,8 @@ def generate_csr(request):
 
     try:
         from cryptography import x509
-        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives import serialization
         from cryptography.hazmat.primitives.asymmetric import rsa
         from cryptography.x509.oid import NameOID
 
@@ -191,7 +119,6 @@ def generate_csr(request):
             .subject_name(x509.Name(name_attrs))
         )
 
-        # Build SAN list — always include CN as a DNS SAN if it looks like a hostname
         san_list = []
         if cn and not cn.replace(".", "").replace("-", "").isdigit():
             san_list.append(x509.DNSName(cn))
@@ -209,7 +136,7 @@ def generate_csr(request):
 
         if san_list:
             builder = builder.add_extension(
-                x509.SubjectAlternativeName(san_list), critical=False
+                x509.SubjectAlternativeName(san_list), critical=False,
             )
 
         csr = builder.sign(key, hashes.SHA256())
@@ -231,7 +158,11 @@ def generate_csr(request):
             f.write(csr_pem)
 
         logger.info("CSR generated by %s for CN=%s", request.user, cn)
-        messages.success(request, f"CSR generated for {cn}. Submit it to your CA, then upload the signed certificate.")
+        messages.success(
+            request,
+            f"CSR generated for {cn}. Submit it to your CA, "
+            f"then upload the signed certificate.",
+        )
 
     except Exception as exc:
         logger.error("generate_csr: %s", exc, exc_info=True)
@@ -239,6 +170,10 @@ def generate_csr(request):
 
     return redirect("cert_settings")
 
+
+# ---------------------------------------------------------------------------
+# Certificate upload
+# ---------------------------------------------------------------------------
 
 @_staff_required
 @require_POST
@@ -263,8 +198,8 @@ def upload_signed_cert(request):
         with open(CSR_KEY_FILE, "rb") as f:
             key_content = f.read()
 
-        _validate_cert_key_pair(cert_content, key_content)
-        _install_cert_and_key(cert_content, key_content)
+        validate_cert_key_pair(cert_content, key_content)
+        install_cert_and_key(cert_content, key_content)
 
         for path in (CSR_KEY_FILE, PENDING_CSR_FILE):
             try:
@@ -275,10 +210,16 @@ def upload_signed_cert(request):
         logger.info("Signed certificate installed by %s", request.user)
 
         try:
-            _reload_nginx()
-            messages.success(request, "Certificate installed and nginx reloaded successfully.")
+            reload_nginx()
+            messages.success(
+                request,
+                "Certificate installed and nginx reloaded successfully.",
+            )
         except RuntimeError as exc:
-            messages.warning(request, f"Certificate installed but nginx reload failed: {exc}")
+            messages.warning(
+                request,
+                f"Certificate installed but nginx reload failed: {exc}",
+            )
 
     except ValueError as exc:
         messages.error(request, str(exc))
@@ -297,23 +238,31 @@ def upload_own_cert(request):
     key_file = request.FILES.get("key_file")
 
     if not cert_file or not key_file:
-        messages.error(request, "Both certificate and private key files are required.")
+        messages.error(
+            request, "Both certificate and private key files are required.",
+        )
         return redirect("cert_settings")
 
     try:
         cert_content = cert_file.read()
         key_content = key_file.read()
 
-        _validate_cert_key_pair(cert_content, key_content)
-        _install_cert_and_key(cert_content, key_content)
+        validate_cert_key_pair(cert_content, key_content)
+        install_cert_and_key(cert_content, key_content)
 
         logger.info("Certificate and key uploaded by %s", request.user)
 
         try:
-            _reload_nginx()
-            messages.success(request, "Certificate installed and nginx reloaded successfully.")
+            reload_nginx()
+            messages.success(
+                request,
+                "Certificate installed and nginx reloaded successfully.",
+            )
         except RuntimeError as exc:
-            messages.warning(request, f"Certificate installed but nginx reload failed: {exc}")
+            messages.warning(
+                request,
+                f"Certificate installed but nginx reload failed: {exc}",
+            )
 
     except ValueError as exc:
         messages.error(request, str(exc))
@@ -324,13 +273,18 @@ def upload_own_cert(request):
     return redirect("cert_settings")
 
 
+# ---------------------------------------------------------------------------
+# Self-signed certificate generation
+# ---------------------------------------------------------------------------
+
 @_staff_required
 @require_POST
 def generate_self_signed(request):
     """Generate a fresh self-signed certificate (10-year validity)."""
     try:
         from cryptography import x509
-        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives import serialization
         from cryptography.hazmat.primitives.asymmetric import rsa
         from cryptography.x509.oid import NameOID
 
@@ -348,7 +302,9 @@ def generate_self_signed(request):
             .serial_number(x509.random_serial_number())
             .not_valid_before(now)
             .not_valid_after(now + datetime.timedelta(days=3650))
-            .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+            .add_extension(
+                x509.BasicConstraints(ca=False, path_length=None), critical=True,
+            )
             .sign(key, hashes.SHA256())
         )
 
@@ -359,14 +315,20 @@ def generate_self_signed(request):
             serialization.NoEncryption(),
         )
 
-        _install_cert_and_key(cert_pem, key_pem)
+        install_cert_and_key(cert_pem, key_pem)
         logger.info("Self-signed certificate regenerated by %s", request.user)
 
         try:
-            _reload_nginx()
-            messages.success(request, "New self-signed certificate generated and nginx reloaded.")
+            reload_nginx()
+            messages.success(
+                request,
+                "New self-signed certificate generated and nginx reloaded.",
+            )
         except RuntimeError as exc:
-            messages.warning(request, f"Certificate generated but nginx reload failed: {exc}")
+            messages.warning(
+                request,
+                f"Certificate generated but nginx reload failed: {exc}",
+            )
 
     except Exception as exc:
         logger.error("generate_self_signed: %s", exc, exc_info=True)
@@ -374,6 +336,10 @@ def generate_self_signed(request):
 
     return redirect("cert_settings")
 
+
+# ---------------------------------------------------------------------------
+# Port change
+# ---------------------------------------------------------------------------
 
 @_staff_required
 @require_POST
@@ -389,12 +355,12 @@ def change_port(request):
         messages.error(request, "Invalid port number. Must be between 1 and 65535.")
         return redirect("cert_settings")
 
-    current_port = _get_current_port()
+    current_port = get_current_port()
     if new_port == current_port:
         messages.info(request, f"Port is already {new_port}.")
         return redirect("cert_settings")
 
-    nginx_conf = _find_nginx_conf()
+    nginx_conf = find_nginx_conf()
     if not nginx_conf:
         messages.error(request, "Cannot find nginx configuration file.")
         return redirect("cert_settings")
@@ -403,45 +369,61 @@ def change_port(request):
         with open(nginx_conf) as f:
             original = f.read()
 
-        updated = re.sub(r"(listen\s+)\d+(\s+ssl)", rf"\g<1>{new_port}\2", original)
+        updated = re.sub(
+            r"(listen\s+)\d+(\s+ssl)", rf"\g<1>{new_port}\2", original,
+        )
 
         if updated == original:
-            messages.warning(request, "Could not locate the listen directive in the nginx config.")
+            messages.warning(
+                request,
+                "Could not locate the listen directive in the nginx config.",
+            )
             return redirect("cert_settings")
 
-        # Write via sudo tee
         write = subprocess.run(
             ["sudo", "tee", nginx_conf],
             input=updated.encode(),
             capture_output=True, shell=False,
         )
         if write.returncode != 0:
-            messages.error(request, f"Failed to write nginx config: {write.stderr.decode().strip()}")
+            messages.error(
+                request,
+                f"Failed to write nginx config: {write.stderr.decode().strip()}",
+            )
             return redirect("cert_settings")
 
-        # Validate — roll back on failure
         test = subprocess.run(
             ["sudo", "nginx", "-t"],
             capture_output=True, text=True, shell=False,
         )
         if test.returncode != 0:
-            subprocess.run(["sudo", "tee", nginx_conf],
-                           input=original.encode(), capture_output=True, shell=False)
-            messages.error(request, f"nginx config test failed (rolled back): {test.stderr.strip()}")
+            subprocess.run(
+                ["sudo", "tee", nginx_conf],
+                input=original.encode(), capture_output=True, shell=False,
+            )
+            messages.error(
+                request,
+                f"nginx config test failed (rolled back): {test.stderr.strip()}",
+            )
             return redirect("cert_settings")
 
-        # Update .env
         if os.path.exists(ENV_FILE):
             with open(ENV_FILE) as f:
                 env = f.read()
-            new_env = re.sub(r"^WEB_PORT=\d+", f"WEB_PORT={new_port}", env, flags=re.MULTILINE)
+            new_env = re.sub(
+                r"^WEB_PORT=\d+", f"WEB_PORT={new_port}", env,
+                flags=re.MULTILINE,
+            )
             if new_env == env:
                 new_env = env.rstrip("\n") + f"\nWEB_PORT={new_port}\n"
             with open(ENV_FILE, "w") as f:
                 f.write(new_env)
 
-        _reload_nginx()
-        logger.info("HTTPS port changed %d → %d by %s", current_port, new_port, request.user)
+        reload_nginx()
+        logger.info(
+            "HTTPS port changed %d -> %d by %s",
+            current_port, new_port, request.user,
+        )
 
         host = request.get_host().split(":")[0]
         return redirect(f"https://{host}:{new_port}/settings/certificates/")
@@ -450,3 +432,140 @@ def change_port(request):
         logger.error("change_port: %s", exc, exc_info=True)
         messages.error(request, f"Port change failed: {exc}")
         return redirect("cert_settings")
+
+
+# ---------------------------------------------------------------------------
+# ACME views
+# ---------------------------------------------------------------------------
+
+@_staff_required
+@require_POST
+def acme_configure(request):
+    """Save ACME settings and register an account with the CA."""
+    from apps.certificates import acme
+    from apps.certificates.tasks import _get_verify
+    from apps.certificates.tasks import _cleanup_ca_bundle
+
+    config = AcmeConfig.get_config()
+
+    provider = request.POST.get("provider", "letsencrypt")
+    domain = request.POST.get("domain", "").strip()
+    email = request.POST.get("email", "").strip()
+    challenge_type = request.POST.get("challenge_type", "http-01")
+    ca_bundle = request.POST.get("ca_bundle", "").strip()
+    skip_tls = request.POST.get("skip_tls_verify") == "on"
+
+    if not domain:
+        messages.error(request, "Domain is required.")
+        return redirect("cert_settings")
+
+    # Auto-fill directory URL from provider preset
+    if provider in DIRECTORY_URLS:
+        directory_url = DIRECTORY_URLS[provider]
+    else:
+        directory_url = request.POST.get("directory_url", "").strip()
+        if not directory_url:
+            messages.error(request, "Directory URL is required for custom providers.")
+            return redirect("cert_settings")
+
+    config.provider = provider
+    config.directory_url = directory_url
+    config.domain = domain
+    config.email = email
+    config.challenge_type = challenge_type
+    config.ca_bundle = ca_bundle
+    config.skip_tls_verify = skip_tls
+    config.save()
+
+    # Register ACME account
+    if not config.acme_account_key_pem:
+        key_pem = acme.generate_account_key()
+        config.acme_account_key_pem = key_pem.decode("utf-8")
+        config.save(update_fields=["acme_account_key_pem", "updated_at"])
+
+    verify = _get_verify(config)
+    try:
+        account_url = acme.register_account(
+            config.acme_account_key_pem,
+            config.directory_url,
+            email=config.email or None,
+            verify=verify,
+        )
+        config.acme_account_url = account_url
+        config.save(update_fields=["acme_account_url", "updated_at"])
+        AcmeLog.log("account_registered", f"Account: {account_url}")
+        AcmeLog.log("config_changed", f"Configured by {request.user}")
+        messages.success(
+            request,
+            f"ACME configured and account registered with "
+            f"{config.get_provider_display()}.",
+        )
+    except Exception as exc:
+        logger.error("ACME account registration failed: %s", exc)
+        messages.error(request, f"Account registration failed: {exc}")
+    finally:
+        _cleanup_ca_bundle(verify)
+
+    return redirect("cert_settings")
+
+
+@_staff_required
+@require_POST
+def acme_issue(request):
+    """Trigger ACME certificate issuance as a background task."""
+    from apps.certificates.tasks import issue_acme_certificate
+
+    config = AcmeConfig.get_config()
+    if not config.domain or not config.acme_account_url:
+        messages.error(request, "ACME is not configured. Configure it first.")
+        return redirect("cert_settings")
+
+    issue_acme_certificate.delay()
+    AcmeLog.log("renewal_triggered", f"Manual issuance by {request.user}")
+    messages.info(
+        request,
+        "Certificate issuance started. This page will update when complete.",
+    )
+    return redirect("cert_settings")
+
+
+@_staff_required
+def acme_status(request):
+    """HTMX endpoint: return current ACME status as an HTML partial."""
+    config = AcmeConfig.get_config()
+    cert_info = get_cert_info()
+
+    cert_days_remaining = None
+    if cert_info and "not_after" in cert_info:
+        delta = cert_info["not_after"] - datetime.datetime.now(datetime.timezone.utc)
+        cert_days_remaining = delta.days
+
+    return render(request, "certificates/partials/acme_status.html", {
+        "acme": config,
+        "cert_days_remaining": cert_days_remaining,
+        "acme_logs": AcmeLog.objects.all()[:5],
+    })
+
+
+@_staff_required
+@require_POST
+def acme_dns_confirm(request):
+    """User confirms the DNS TXT record has been created."""
+    broker_url = getattr(settings, "CELERY_BROKER_URL", "redis://127.0.0.1:6379/0")
+    r = redis.Redis.from_url(broker_url)
+    r.set(REDIS_DNS_CONFIRM_KEY, "1", ex=3600)
+
+    messages.info(request, "DNS confirmation sent. Waiting for validation...")
+    return redirect("cert_settings")
+
+
+@_staff_required
+@require_POST
+def acme_disable(request):
+    """Disable ACME automation. Keeps the current certificate in place."""
+    config = AcmeConfig.get_config()
+    config.is_enabled = False
+    config.save(update_fields=["is_enabled", "updated_at"])
+    AcmeLog.log("acme_disabled", f"Disabled by {request.user}")
+    messages.success(request, "ACME automation disabled. Current certificate is unchanged.")
+    return redirect("cert_settings")

--- a/apps/certificates/views.py
+++ b/apps/certificates/views.py
@@ -457,7 +457,7 @@ def acme_configure(request):
 
     if not domain:
         messages.error(request, "Domain is required.")
-        return redirect("cert_settings")
+        return redirect("/settings/certificates/?tab=acme")
 
     # Auto-fill directory URL from provider preset
     if provider in DIRECTORY_URLS:
@@ -466,7 +466,7 @@ def acme_configure(request):
         directory_url = request.POST.get("directory_url", "").strip()
         if not directory_url:
             messages.error(request, "Directory URL is required for custom providers.")
-            return redirect("cert_settings")
+            return redirect("/settings/certificates/?tab=acme")
 
     config.provider = provider
     config.directory_url = directory_url
@@ -506,7 +506,7 @@ def acme_configure(request):
     finally:
         _cleanup_ca_bundle(verify)
 
-    return redirect("cert_settings")
+    return redirect("/settings/certificates/?tab=acme")
 
 
 @_staff_required
@@ -518,7 +518,7 @@ def acme_issue(request):
     config = AcmeConfig.get_config()
     if not config.domain or not config.acme_account_url:
         messages.error(request, "ACME is not configured. Configure it first.")
-        return redirect("cert_settings")
+        return redirect("/settings/certificates/?tab=acme")
 
     issue_acme_certificate.delay()
     AcmeLog.log("renewal_triggered", f"Manual issuance by {request.user}")
@@ -526,7 +526,7 @@ def acme_issue(request):
         request,
         "Certificate issuance started. This page will update when complete.",
     )
-    return redirect("cert_settings")
+    return redirect("/settings/certificates/?tab=acme")
 
 
 @_staff_required
@@ -556,7 +556,7 @@ def acme_dns_confirm(request):
     r.set(REDIS_DNS_CONFIRM_KEY, "1", ex=3600)
 
     messages.info(request, "DNS confirmation sent. Waiting for validation...")
-    return redirect("cert_settings")
+    return redirect("/settings/certificates/?tab=acme")
 
 
 @_staff_required
@@ -568,7 +568,7 @@ def acme_disable(request):
     config.save(update_fields=["is_enabled", "updated_at"])
     AcmeLog.log("acme_disabled", f"Disabled by {request.user}")
     messages.success(request, "ACME automation disabled. Current certificate is unchanged.")
-    return redirect("cert_settings")
+    return redirect("/settings/certificates/?tab=acme")
 
 
 @_staff_required
@@ -592,4 +592,4 @@ def acme_reset(request):
     config.save()
     AcmeLog.log("config_changed", f"Configuration reset by {request.user}")
     messages.success(request, "ACME configuration reset. You can now reconfigure.")
-    return redirect("cert_settings")
+    return redirect("/settings/certificates/?tab=acme")

--- a/apps/certificates/views.py
+++ b/apps/certificates/views.py
@@ -512,20 +512,98 @@ def acme_configure(request):
 @_staff_required
 @require_POST
 def acme_issue(request):
-    """Trigger ACME certificate issuance as a background task."""
+    """Start ACME certificate issuance.
+
+    For HTTP-01: triggers the full flow as a background task.
+    For DNS-01: creates the order synchronously, saves the TXT record
+    value to the database, and returns to the page so the user can see
+    it and create the DNS record at their own pace.
+    """
+    from apps.certificates import acme
     from apps.certificates.tasks import issue_acme_certificate
+    from apps.certificates.tasks import _get_verify
+    from apps.certificates.tasks import _cleanup_ca_bundle
 
     config = AcmeConfig.get_config()
     if not config.domain or not config.acme_account_url:
         messages.error(request, "ACME is not configured. Configure it first.")
         return redirect("/settings/certificates/?tab=acme")
 
-    issue_acme_certificate.delay()
-    AcmeLog.log("renewal_triggered", f"Manual issuance by {request.user}")
-    messages.info(
-        request,
-        "Certificate issuance started. This page will update when complete.",
-    )
+    if config.challenge_type == "http-01":
+        # HTTP-01: fully automated, run everything in the background
+        issue_acme_certificate.delay()
+        AcmeLog.log("renewal_triggered", f"Manual issuance by {request.user}")
+        messages.info(
+            request,
+            "Certificate issuance started. This may take a minute.",
+        )
+        return redirect("/settings/certificates/?tab=acme")
+
+    # DNS-01: create order and get TXT value synchronously so the user can see it
+    verify = _get_verify(config)
+    try:
+        key_pem = config.acme_account_key_pem
+        account_url = config.acme_account_url
+
+        order_url, order = acme.create_order(
+            key_pem, account_url, config.directory_url, config.domain,
+            verify=verify,
+        )
+        AcmeLog.log("order_created", f"Order for {config.domain}")
+
+        # Save order URL for the background task to use later
+        config.last_renewal_error = ""
+
+        if order.get("status") in ("ready", "valid"):
+            # Internal CA that skips challenges — go straight to background task
+            issue_acme_certificate.delay()
+            messages.info(request, "CA does not require a challenge. Issuing certificate...")
+            return redirect("/settings/certificates/?tab=acme")
+
+        # Get the DNS-01 challenge
+        for auth_url in order.get("authorizations", []):
+            auth = acme.get_authorization(
+                key_pem, account_url, auth_url, verify=verify,
+            )
+            if auth.get("status") == "valid":
+                continue
+
+            challenge = acme.get_dns01_challenge(auth)
+            if not challenge:
+                messages.error(request, "No DNS-01 challenge available from the CA.")
+                return redirect("/settings/certificates/?tab=acme")
+
+            txt_value = acme.compute_dns01_txt_value(key_pem, challenge["token"])
+
+            # Save to database — this persists until the user confirms
+            config.dns_txt_value = txt_value
+            config.dns_challenge_pending = True
+            config.save(update_fields=[
+                "dns_txt_value", "dns_challenge_pending",
+                "last_renewal_error", "updated_at",
+            ])
+
+            AcmeLog.log(
+                "challenge_completed",
+                f"DNS-01 TXT record ready: _acme-challenge.{config.domain}",
+            )
+            messages.success(
+                request,
+                "DNS TXT record generated. Create the record at your DNS "
+                "provider, then click the confirm button.",
+            )
+            return redirect("/settings/certificates/?tab=acme")
+
+        # All authorizations already valid
+        issue_acme_certificate.delay()
+        messages.info(request, "All authorizations valid. Issuing certificate...")
+
+    except Exception as exc:
+        logger.error("ACME order creation failed: %s", exc)
+        messages.error(request, f"Failed to create order: {exc}")
+    finally:
+        _cleanup_ca_bundle(verify)
+
     return redirect("/settings/certificates/?tab=acme")
 
 
@@ -550,12 +628,23 @@ def acme_status(request):
 @_staff_required
 @require_POST
 def acme_dns_confirm(request):
-    """User confirms the DNS TXT record has been created."""
+    """User confirms the DNS TXT record has been created. Trigger finalization."""
+    from apps.certificates.tasks import issue_acme_certificate
+
+    # Set the Redis flag so the task knows DNS is confirmed
     broker_url = getattr(settings, "CELERY_BROKER_URL", "redis://127.0.0.1:6379/0")
     r = redis.Redis.from_url(broker_url)
     r.set(REDIS_DNS_CONFIRM_KEY, "1", ex=3600)
 
-    messages.info(request, "DNS confirmation sent. Waiting for validation...")
+    # Trigger the background task — it will pick up the existing order
+    # and respond to the challenge now that DNS is confirmed
+    issue_acme_certificate.delay()
+    AcmeLog.log("renewal_triggered", "DNS-01 confirmed, starting finalization")
+
+    messages.info(
+        request,
+        "DNS confirmed. Certificate issuance in progress — this may take a minute.",
+    )
     return redirect("/settings/certificates/?tab=acme")
 
 

--- a/apps/certificates/views.py
+++ b/apps/certificates/views.py
@@ -531,6 +531,13 @@ def acme_issue(request):
 
     if config.challenge_type == "http-01":
         # HTTP-01: fully automated, run everything in the background
+        config.issuing_in_progress = True
+        config.issuing_stage = "Starting..."
+        config.last_renewal_error = ""
+        config.save(update_fields=[
+            "issuing_in_progress", "issuing_stage",
+            "last_renewal_error", "updated_at",
+        ])
         issue_acme_certificate.delay()
         AcmeLog.log("renewal_triggered", f"Manual issuance by {request.user}")
         messages.info(
@@ -636,8 +643,17 @@ def acme_dns_confirm(request):
     r = redis.Redis.from_url(broker_url)
     r.set(REDIS_DNS_CONFIRM_KEY, "1", ex=3600)
 
-    # Trigger the background task — it will pick up the existing order
-    # and respond to the challenge now that DNS is confirmed
+    # Mark as in progress and trigger the background task
+    config = AcmeConfig.get_config()
+    config.issuing_in_progress = True
+    config.issuing_stage = "DNS confirmed, responding to challenge..."
+    config.dns_challenge_pending = False
+    config.last_renewal_error = ""
+    config.save(update_fields=[
+        "issuing_in_progress", "issuing_stage",
+        "dns_challenge_pending", "last_renewal_error", "updated_at",
+    ])
+
     issue_acme_certificate.delay()
     AcmeLog.log("renewal_triggered", "DNS-01 confirmed, starting finalization")
 

--- a/apps/certificates/views.py
+++ b/apps/certificates/views.py
@@ -718,6 +718,7 @@ def acme_status(request):
         "acme": config,
         "cert_days_remaining": cert_days_remaining,
         "acme_logs": AcmeLog.objects.all()[:5],
+        "is_poll": request.GET.get("poll") == "1",
     })
 
 

--- a/apps/certificates/views.py
+++ b/apps/certificates/views.py
@@ -492,6 +492,7 @@ def acme_configure(request):
     config.dns_api_token = request.POST.get("dns_api_token", "")
     config.dns_api_secret = request.POST.get("dns_api_secret", "")
     config.dns_zone_id = request.POST.get("dns_zone_id", "")
+    config.ip_sans = request.POST.get("ip_sans", "").strip()
 
     config.save()
 
@@ -633,9 +634,10 @@ def acme_issue(request):
         key_pem = config.acme_account_key_pem
         account_url = config.acme_account_url
 
+        ip_sans = [ip.strip() for ip in config.ip_sans.split(",") if ip.strip()] if config.ip_sans else []
         order_url, order = acme.create_order(
             key_pem, account_url, config.directory_url, config.domain,
-            verify=verify,
+            ip_sans=ip_sans, verify=verify,
         )
         AcmeLog.log("order_created", f"Order for {config.domain}")
 
@@ -784,6 +786,7 @@ def acme_reset(request):
     config.dns_api_token = ""
     config.dns_api_secret = ""
     config.dns_zone_id = ""
+    config.ip_sans = ""
     config.pending_order_url = ""
     config.pending_challenge_url = ""
     config.issuing_in_progress = False

--- a/apps/certificates/views.py
+++ b/apps/certificates/views.py
@@ -569,3 +569,27 @@ def acme_disable(request):
     AcmeLog.log("acme_disabled", f"Disabled by {request.user}")
     messages.success(request, "ACME automation disabled. Current certificate is unchanged.")
     return redirect("cert_settings")
+
+
+@_staff_required
+@require_POST
+def acme_reset(request):
+    """Reset ACME configuration so the user can reconfigure from scratch."""
+    config = AcmeConfig.get_config()
+    config.is_enabled = False
+    config.provider = "letsencrypt"
+    config.directory_url = DIRECTORY_URLS["letsencrypt"]
+    config.domain = ""
+    config.email = ""
+    config.challenge_type = "http-01"
+    config.acme_account_key_pem = ""
+    config.acme_account_url = ""
+    config.ca_bundle = ""
+    config.skip_tls_verify = False
+    config.dns_txt_value = ""
+    config.dns_challenge_pending = False
+    config.last_renewal_error = ""
+    config.save()
+    AcmeLog.log("config_changed", f"Configuration reset by {request.user}")
+    messages.success(request, "ACME configuration reset. You can now reconfigure.")
+    return redirect("cert_settings")

--- a/apps/certificates/views.py
+++ b/apps/certificates/views.py
@@ -452,7 +452,12 @@ def acme_configure(request):
     domain = request.POST.get("domain", "").strip()
     email = request.POST.get("email", "").strip()
     challenge_type = request.POST.get("challenge_type", "http-01")
-    ca_bundle = request.POST.get("ca_bundle", "").strip()
+    # CA bundle: accept file upload or pasted PEM text
+    ca_bundle_file = request.FILES.get("ca_bundle_file")
+    if ca_bundle_file:
+        ca_bundle = ca_bundle_file.read().decode("utf-8").strip()
+    else:
+        ca_bundle = request.POST.get("ca_bundle", "").strip()
     skip_tls = request.POST.get("skip_tls_verify") == "on"
 
     if not domain:

--- a/apps/certificates/views.py
+++ b/apps/certificates/views.py
@@ -492,6 +492,7 @@ def acme_configure(request):
 
     verify = _get_verify(config)
     try:
+        # Step 1: Register ACME account
         account_url = acme.register_account(
             config.acme_account_key_pem,
             config.directory_url,
@@ -502,11 +503,73 @@ def acme_configure(request):
         config.save(update_fields=["acme_account_url", "updated_at"])
         AcmeLog.log("account_registered", f"Account: {account_url}")
         AcmeLog.log("config_changed", f"Configured by {request.user}")
-        messages.success(
-            request,
-            f"ACME configured and account registered with "
-            f"{config.get_provider_display()}.",
+
+        # Step 2: Test DNS API if provider is configured
+        dns_api_ok = False
+        if (challenge_type == "dns-01"
+                and config.dns_provider
+                and config.dns_provider not in ("none", "manual")):
+            try:
+                from apps.certificates import dns_providers
+
+                # Quick validation — create and immediately delete a test record
+                dns_providers.create_txt_record(
+                    config.dns_provider,
+                    config.domain,
+                    "proxmigrate-api-test",
+                    api_token=config.dns_api_token,
+                    api_secret=config.dns_api_secret,
+                    zone_id=config.dns_zone_id,
+                )
+                dns_providers.delete_txt_record(
+                    config.dns_provider,
+                    config.domain,
+                    api_token=config.dns_api_token,
+                    api_secret=config.dns_api_secret,
+                    zone_id=config.dns_zone_id,
+                )
+                dns_api_ok = True
+                AcmeLog.log("config_changed",
+                            f"DNS API test passed ({config.get_dns_provider_display()})")
+            except Exception as exc:
+                logger.error("DNS API test failed: %s", exc)
+                messages.error(
+                    request,
+                    f"ACME account registered, but DNS API test failed: {exc}. "
+                    f"Check your API credentials and try again.",
+                )
+                return redirect("/settings/certificates/?tab=acme")
+
+        # Step 3: Auto-issue if we can (HTTP-01 or DNS-01 with working API)
+        can_auto_issue = (
+            challenge_type == "http-01"
+            or (challenge_type == "dns-01" and dns_api_ok)
         )
+
+        if can_auto_issue:
+            from apps.certificates.tasks import issue_acme_certificate
+
+            config.issuing_in_progress = True
+            config.issuing_stage = "Starting certificate issuance..."
+            config.last_renewal_error = ""
+            config.save(update_fields=[
+                "issuing_in_progress", "issuing_stage",
+                "last_renewal_error", "updated_at",
+            ])
+            issue_acme_certificate.delay()
+            AcmeLog.log("renewal_triggered", f"Auto-issue after configure by {request.user}")
+            messages.success(
+                request,
+                f"ACME configured with {config.get_provider_display()}. "
+                f"Certificate issuance started automatically.",
+            )
+        else:
+            messages.success(
+                request,
+                f"ACME configured and account registered with "
+                f"{config.get_provider_display()}.",
+            )
+
     except Exception as exc:
         logger.error("ACME account registration failed: %s", exc)
         messages.error(request, f"Account registration failed: {exc}")

--- a/apps/certificates/views.py
+++ b/apps/certificates/views.py
@@ -63,7 +63,9 @@ def cert_settings(request):
     cert_days_remaining = None
     if cert_info and "not_after" in cert_info:
         delta = cert_info["not_after"] - datetime.datetime.now(datetime.timezone.utc)
-        cert_days_remaining = delta.days
+        total_seconds = delta.total_seconds()
+        cert_days_remaining = delta.days if total_seconds > 0 else -1
+        cert_hours_remaining = int(total_seconds // 3600) if total_seconds > 0 else 0
 
     acme_config = AcmeConfig.get_config()
     acme_logs = AcmeLog.objects.all()[:10]
@@ -71,6 +73,7 @@ def cert_settings(request):
     return render(request, "certificates/settings.html", {
         "cert_info": cert_info,
         "cert_days_remaining": cert_days_remaining,
+        "cert_hours_remaining": cert_hours_remaining,
         "pending_csr": get_pending_csr(),
         "has_csr_key": os.path.exists(CSR_KEY_FILE),
         "current_port": get_current_port(),
@@ -705,7 +708,9 @@ def acme_status(request):
     cert_days_remaining = None
     if cert_info and "not_after" in cert_info:
         delta = cert_info["not_after"] - datetime.datetime.now(datetime.timezone.utc)
-        cert_days_remaining = delta.days
+        total_seconds = delta.total_seconds()
+        cert_days_remaining = delta.days if total_seconds > 0 else -1
+        cert_hours_remaining = int(total_seconds // 3600) if total_seconds > 0 else 0
 
     return render(request, "certificates/partials/acme_status.html", {
         "acme": config,

--- a/apps/certificates/views.py
+++ b/apps/certificates/views.py
@@ -452,12 +452,15 @@ def acme_configure(request):
     domain = request.POST.get("domain", "").strip()
     email = request.POST.get("email", "").strip()
     challenge_type = request.POST.get("challenge_type", "http-01")
-    # CA bundle: accept file upload or pasted PEM text
+    # CA bundle: accept file upload, pasted PEM text, or keep existing
     ca_bundle_file = request.FILES.get("ca_bundle_file")
+    ca_bundle_text = request.POST.get("ca_bundle", "").strip()
     if ca_bundle_file:
         ca_bundle = ca_bundle_file.read().decode("utf-8").strip()
+    elif ca_bundle_text:
+        ca_bundle = ca_bundle_text
     else:
-        ca_bundle = request.POST.get("ca_bundle", "").strip()
+        ca_bundle = config.ca_bundle  # preserve existing if nothing new provided
     skip_tls = request.POST.get("skip_tls_verify") == "on"
 
     if not domain:

--- a/apps/certificates/views.py
+++ b/apps/certificates/views.py
@@ -582,11 +582,15 @@ def acme_issue(request):
 
             txt_value = acme.compute_dns01_txt_value(key_pem, challenge["token"])
 
-            # Save to database — this persists until the user confirms
+            # Save order URL, challenge URL, and TXT value so the task
+            # can resume this exact order after the user confirms DNS
             config.dns_txt_value = txt_value
             config.dns_challenge_pending = True
+            config.pending_order_url = order_url
+            config.pending_challenge_url = challenge["url"]
             config.save(update_fields=[
                 "dns_txt_value", "dns_challenge_pending",
+                "pending_order_url", "pending_challenge_url",
                 "last_renewal_error", "updated_at",
             ])
 
@@ -693,6 +697,10 @@ def acme_reset(request):
     config.skip_tls_verify = False
     config.dns_txt_value = ""
     config.dns_challenge_pending = False
+    config.pending_order_url = ""
+    config.pending_challenge_url = ""
+    config.issuing_in_progress = False
+    config.issuing_stage = ""
     config.last_renewal_error = ""
     config.save()
     AcmeLog.log("config_changed", f"Configuration reset by {request.user}")

--- a/apps/certificates/views.py
+++ b/apps/certificates/views.py
@@ -475,6 +475,13 @@ def acme_configure(request):
     config.challenge_type = challenge_type
     config.ca_bundle = ca_bundle
     config.skip_tls_verify = skip_tls
+
+    # DNS provider settings (for automated DNS-01)
+    config.dns_provider = request.POST.get("dns_provider", "none")
+    config.dns_api_token = request.POST.get("dns_api_token", "")
+    config.dns_api_secret = request.POST.get("dns_api_secret", "")
+    config.dns_zone_id = request.POST.get("dns_zone_id", "")
+
     config.save()
 
     # Register ACME account
@@ -697,6 +704,10 @@ def acme_reset(request):
     config.skip_tls_verify = False
     config.dns_txt_value = ""
     config.dns_challenge_pending = False
+    config.dns_provider = "none"
+    config.dns_api_token = ""
+    config.dns_api_secret = ""
+    config.dns_zone_id = ""
     config.pending_order_url = ""
     config.pending_challenge_url = ""
     config.issuing_in_progress = False

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -116,6 +116,19 @@ def dashboard(request):
         combined = sorted(import_jobs + create_jobs + lxc_jobs + lxc_clone_jobs + snapshot_logs, key=lambda j: j.created_at, reverse=True)
         recent_jobs = combined[:8]
 
+    # Certificate expiry warning
+    cert_days_remaining = None
+    try:
+        from apps.certificates.helpers import CERT_FILE, get_cert_info
+
+        if os.path.exists(CERT_FILE):
+            cert_info = get_cert_info()
+            if cert_info and "not_after" in cert_info:
+                delta = cert_info["not_after"] - timezone.now()
+                cert_days_remaining = delta.days
+    except Exception:
+        pass
+
     context = {
         "wizard_complete": wizard_complete,
         "proxmox_host": proxmox_host,
@@ -128,6 +141,8 @@ def dashboard(request):
         "ct_total": ct_total,
         "ct_running": ct_running,
         "ct_stopped": ct_stopped,
+        "cert_days_remaining": cert_days_remaining,
+        "cert_expiry_warning": cert_days_remaining is not None and cert_days_remaining <= 30,
         "help_slug": "dashboard",
     }
     return render(request, "core/dashboard.html", context)

--- a/deploy/celery.service.template
+++ b/deploy/celery.service.template
@@ -12,7 +12,9 @@ EnvironmentFile=/opt/proxmigrate/.env
 ExecStart=/opt/proxmigrate/venv/bin/celery \
     -A proxmigrate worker \
     -l info \
-    --concurrency=4
+    --concurrency=4 \
+    -B \
+    --schedule=/opt/proxmigrate/celerybeat-schedule
 Restart=always
 RestartSec=10
 KillSignal=SIGTERM

--- a/deploy/nginx.conf.template
+++ b/deploy/nginx.conf.template
@@ -47,3 +47,6 @@ server {
     # VM console WebSocket proxy — target written by ProxMigrate after wizard completes
     include /opt/proxmigrate/deploy/proxmox_ws.conf;
 }
+
+# ACME HTTP-01 challenge server (managed by ProxMigrate — empty when not in use)
+include /opt/proxmigrate/deploy/acme-challenge.conf;

--- a/install.sh
+++ b/install.sh
@@ -296,8 +296,9 @@ fi
 
 echo "==> Creating runtime directories..."
 UPLOAD_ROOT="${APP_HOME}/uploads"
-mkdir -p "${UPLOAD_ROOT}" "${CERTS_DIR}" "${SSH_DIR}"
-chown -R "${APP_USER}:${APP_USER}" "${UPLOAD_ROOT}" "${CERTS_DIR}" "${SSH_DIR}"
+ACME_CHALLENGE_DIR="${CERTS_DIR}/acme-challenge"
+mkdir -p "${UPLOAD_ROOT}" "${CERTS_DIR}" "${ACME_CHALLENGE_DIR}" "${SSH_DIR}"
+chown -R "${APP_USER}:${APP_USER}" "${UPLOAD_ROOT}" "${CERTS_DIR}" "${ACME_CHALLENGE_DIR}" "${SSH_DIR}"
 chmod 700 "${SSH_DIR}"
 
 # ---------------------------------------------------------------------------
@@ -436,6 +437,7 @@ ${APP_USER} ALL=(ALL) NOPASSWD: /usr/sbin/nginx -s reload
 ${APP_USER} ALL=(ALL) NOPASSWD: /usr/sbin/nginx -t
 ${APP_USER} ALL=(ALL) NOPASSWD: /usr/bin/tee /etc/nginx/sites-available/proxmigrate
 ${APP_USER} ALL=(ALL) NOPASSWD: /usr/bin/tee /etc/nginx/conf.d/proxmigrate.conf
+${APP_USER} ALL=(ALL) NOPASSWD: /usr/bin/tee /opt/proxmigrate/deploy/acme-challenge.conf
 EOF
 chmod 440 "${SUDOERS_FILE}"
 echo "    Sudoers rule written: ${SUDOERS_FILE}"
@@ -485,6 +487,10 @@ CELERY_SERVICE="/etc/systemd/system/proxmigrate-celery.service"
 
 cp "${APP_HOME}/deploy/gunicorn.service.template" "${GUNICORN_SERVICE}"
 cp "${APP_HOME}/deploy/celery.service.template" "${CELERY_SERVICE}"
+
+# Create empty ACME challenge config (populated by ACME automation when needed)
+touch "${APP_HOME}/deploy/acme-challenge.conf"
+chown "${APP_USER}:${APP_USER}" "${APP_HOME}/deploy/acme-challenge.conf"
 
 # Create RuntimeDirectory parent so systemd tmpfiles doesn't complain
 mkdir -p /run/proxmigrate

--- a/proxmigrate/celery.py
+++ b/proxmigrate/celery.py
@@ -1,9 +1,17 @@
 import os
 
 from celery import Celery
+from celery.schedules import crontab
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "proxmigrate.settings.production")
 
 app = Celery("proxmigrate")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks()
+
+app.conf.beat_schedule = {
+    "check-cert-expiry": {
+        "task": "certificates.check_cert_expiry",
+        "schedule": crontab(hour=3, minute=30),
+    },
+}

--- a/proxmigrate/celery.py
+++ b/proxmigrate/celery.py
@@ -12,6 +12,6 @@ app.autodiscover_tasks()
 app.conf.beat_schedule = {
     "check-cert-expiry": {
         "task": "certificates.check_cert_expiry",
-        "schedule": crontab(hour=3, minute=30),
+        "schedule": crontab(hour="*/6", minute=30),  # Every 6 hours: 00:30, 06:30, 12:30, 18:30
     },
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -168,6 +168,7 @@
   // Auto-dismiss notifications after 5s
   // -----------------------------------------------------------------------
   document.querySelectorAll('.notification').forEach(n => {
+    if (n.dataset.persist) return;
     setTimeout(() => {
       n.style.opacity = '0';
       n.style.transition = 'opacity 0.5s';

--- a/templates/certificates/partials/acme_status.html
+++ b/templates/certificates/partials/acme_status.html
@@ -1,0 +1,36 @@
+{# HTMX partial: ACME status for polling during certificate issuance #}
+
+{% if acme.dns_challenge_pending %}
+  <div class="notification is-warning is-light" style="padding:0.75rem 1rem;border-radius:6px;"
+       hx-get="{% url 'acme_status' %}" hx-trigger="every 5s" hx-swap="outerHTML">
+    <i class="fas fa-clock" style="margin-right:0.4rem;"></i>
+    Waiting for DNS record confirmation...
+  </div>
+{% elif acme.last_renewal_error %}
+  <div class="notification is-danger is-light" style="padding:0.75rem 1rem;border-radius:6px;">
+    <i class="fas fa-times-circle" style="margin-right:0.4rem;"></i>
+    <strong>Error:</strong> {{ acme.last_renewal_error }}
+  </div>
+{% elif acme.is_enabled %}
+  <div class="notification is-success is-light" style="padding:0.75rem 1rem;border-radius:6px;">
+    <i class="fas fa-check-circle" style="margin-right:0.4rem;"></i>
+    Certificate issued successfully.
+    {% if cert_days_remaining %}Expires in {{ cert_days_remaining }} days.{% endif %}
+  </div>
+{% else %}
+  <div class="notification is-info is-light" style="padding:0.75rem 1rem;border-radius:6px;"
+       hx-get="{% url 'acme_status' %}" hx-trigger="every 5s" hx-swap="outerHTML">
+    <span class="spinner" style="margin-right:0.4rem;"></span>
+    Certificate issuance in progress...
+  </div>
+{% endif %}
+
+{% if acme_logs %}
+<div style="margin-top:0.75rem;">
+  {% for log in acme_logs %}
+  <div style="font-size:0.75rem;color:#7a7a7a;padding:0.15rem 0;">
+    {{ log.created_at|date:"g:i A" }} &mdash; {{ log.event }}: {{ log.detail|truncatechars:50 }}
+  </div>
+  {% endfor %}
+</div>
+{% endif %}

--- a/templates/certificates/partials/acme_status.html
+++ b/templates/certificates/partials/acme_status.html
@@ -1,7 +1,3 @@
-{# HTMX partial: ACME issuance status.
-   In-progress states include hx-get/hx-trigger to keep polling.
-   Terminal states (success, error) have no polling — they stay put. #}
-
 {% if acme.issuing_in_progress %}
   <div class="proxmigrate-card" style="margin-top:1.25rem;border-left:4px solid #3273dc;border-radius:0 10px 10px 0;"
        hx-get="{% url 'acme_status' %}" hx-trigger="every 3s" hx-target="#acme-status-area" hx-swap="innerHTML">

--- a/templates/certificates/partials/acme_status.html
+++ b/templates/certificates/partials/acme_status.html
@@ -1,6 +1,6 @@
 {% if acme.issuing_in_progress %}
   <div class="proxmigrate-card" style="margin-top:1.25rem;border-left:4px solid #3273dc;border-radius:0 10px 10px 0;"
-       hx-get="{% url 'acme_status' %}" hx-trigger="every 3s" hx-target="#acme-status-area" hx-swap="innerHTML">
+       hx-get="{% url 'acme_status' %}?poll=1" hx-trigger="every 3s" hx-target="#acme-status-area" hx-swap="innerHTML">
     <div class="card-header" style="background:#eff6ff;">
       <i class="fas fa-spinner fa-spin" style="color:#3273dc;"></i> Certificate Issuance In Progress
     </div>
@@ -12,7 +12,7 @@
     </div>
   </div>
 
-{% elif acme.is_enabled and acme.last_renewed_at %}
+{% elif is_poll and acme.is_enabled and acme.last_renewed_at %}
   <div class="proxmigrate-card" style="margin-top:1.25rem;border-left:4px solid #48c78e;border-radius:0 10px 10px 0;">
     <div class="card-header" style="background:#f0fdf4;">
       <i class="fas fa-check-circle" style="color:#48c78e;"></i> Certificate Issued Successfully

--- a/templates/certificates/partials/acme_status.html
+++ b/templates/certificates/partials/acme_status.html
@@ -1,35 +1,56 @@
-{# HTMX partial: ACME status for polling during certificate issuance #}
+{# HTMX partial: ACME issuance status — polled every 3s during issuance #}
 
-{% if acme.dns_challenge_pending %}
-  <div class="notification is-warning is-light" style="padding:0.75rem 1rem;border-radius:6px;"
-       hx-get="{% url 'acme_status' %}" hx-trigger="every 5s" hx-swap="outerHTML">
-    <i class="fas fa-clock" style="margin-right:0.4rem;"></i>
-    Waiting for DNS record confirmation...
+{% if acme.issuing_in_progress %}
+  <div class="proxmigrate-card" style="margin-top:1.25rem;border-left:4px solid #3273dc;border-radius:0 10px 10px 0;"
+       hx-get="{% url 'acme_status' %}" hx-trigger="every 3s" hx-swap="outerHTML">
+    <div class="card-header" style="background:#eff6ff;">
+      <i class="fas fa-spinner fa-spin" style="color:#3273dc;"></i> Certificate Issuance In Progress
+    </div>
+    <div class="card-body">
+      <div style="font-size:0.85rem;color:#4a4a4a;">
+        <span class="spinner" style="margin-right:0.4rem;"></span>
+        {{ acme.issuing_stage|default:"Working..." }}
+      </div>
+    </div>
   </div>
+
+{% elif acme.is_enabled and acme.last_renewed_at %}
+  <div class="proxmigrate-card" style="margin-top:1.25rem;border-left:4px solid #48c78e;border-radius:0 10px 10px 0;">
+    <div class="card-header" style="background:#f0fdf4;">
+      <i class="fas fa-check-circle" style="color:#48c78e;"></i> Certificate Issued Successfully
+    </div>
+    <div class="card-body">
+      <div style="font-size:0.85rem;color:#257953;">
+        Certificate installed and nginx reloaded.
+        {% if cert_days_remaining %}Expires in {{ cert_days_remaining }} days.{% endif %}
+      </div>
+      <p style="font-size:0.78rem;color:#7a7a7a;margin-top:0.5rem;">
+        Renewed: {{ acme.last_renewed_at|date:"N j, Y g:i A" }}
+      </p>
+    </div>
+  </div>
+
 {% elif acme.last_renewal_error %}
-  <div class="notification is-danger is-light" style="padding:0.75rem 1rem;border-radius:6px;">
-    <i class="fas fa-times-circle" style="margin-right:0.4rem;"></i>
-    <strong>Error:</strong> {{ acme.last_renewal_error }}
+  <div class="proxmigrate-card" style="margin-top:1.25rem;border-left:4px solid #f14668;border-radius:0 10px 10px 0;">
+    <div class="card-header" style="background:#fef2f2;">
+      <i class="fas fa-times-circle" style="color:#f14668;"></i> Certificate Issuance Failed
+    </div>
+    <div class="card-body">
+      <div style="font-size:0.85rem;color:#cc0f35;">
+        {{ acme.last_renewal_error }}
+      </div>
+    </div>
   </div>
-{% elif acme.is_enabled %}
-  <div class="notification is-success is-light" style="padding:0.75rem 1rem;border-radius:6px;">
-    <i class="fas fa-check-circle" style="margin-right:0.4rem;"></i>
-    Certificate issued successfully.
-    {% if cert_days_remaining %}Expires in {{ cert_days_remaining }} days.{% endif %}
-  </div>
+
 {% else %}
-  <div class="notification is-info is-light" style="padding:0.75rem 1rem;border-radius:6px;"
-       hx-get="{% url 'acme_status' %}" hx-trigger="every 5s" hx-swap="outerHTML">
-    <span class="spinner" style="margin-right:0.4rem;"></span>
-    Certificate issuance in progress...
-  </div>
+  {# Nothing to show — no issuance attempted yet #}
 {% endif %}
 
 {% if acme_logs %}
 <div style="margin-top:0.75rem;">
   {% for log in acme_logs %}
   <div style="font-size:0.75rem;color:#7a7a7a;padding:0.15rem 0;">
-    {{ log.created_at|date:"g:i A" }} &mdash; {{ log.event }}: {{ log.detail|truncatechars:50 }}
+    {{ log.created_at|date:"g:i A" }} — {{ log.event }}: {{ log.detail|truncatechars:50 }}
   </div>
   {% endfor %}
 </div>

--- a/templates/certificates/partials/acme_status.html
+++ b/templates/certificates/partials/acme_status.html
@@ -25,8 +25,26 @@
       <p style="font-size:0.78rem;color:#7a7a7a;margin-top:0.5rem;">
         Renewed: {{ acme.last_renewed_at|date:"N j, Y g:i A" }}
       </p>
+      <p style="font-size:0.78rem;color:#7a7a7a;margin-top:0.5rem;">
+        <i class="fas fa-sync-alt" style="margin-right:0.3rem;"></i>
+        Page will refresh in <strong><span id="acme-countdown">10</span></strong> seconds...
+      </p>
     </div>
   </div>
+  <script>
+    (function() {
+      var seconds = 10;
+      var el = document.getElementById('acme-countdown');
+      var timer = setInterval(function() {
+        seconds--;
+        if (el) el.textContent = seconds;
+        if (seconds <= 0) {
+          clearInterval(timer);
+          window.location.href = '/settings/certificates/?tab=acme';
+        }
+      }, 1000);
+    })();
+  </script>
 
 {% elif acme.last_renewal_error %}
   <div class="proxmigrate-card" style="margin-top:1.25rem;border-left:4px solid #f14668;border-radius:0 10px 10px 0;">

--- a/templates/certificates/partials/acme_status.html
+++ b/templates/certificates/partials/acme_status.html
@@ -1,8 +1,10 @@
-{# HTMX partial: ACME issuance status — polled every 3s during issuance #}
+{# HTMX partial: ACME issuance status.
+   In-progress states include hx-get/hx-trigger to keep polling.
+   Terminal states (success, error) have no polling — they stay put. #}
 
 {% if acme.issuing_in_progress %}
   <div class="proxmigrate-card" style="margin-top:1.25rem;border-left:4px solid #3273dc;border-radius:0 10px 10px 0;"
-       hx-get="{% url 'acme_status' %}" hx-trigger="every 3s" hx-swap="outerHTML">
+       hx-get="{% url 'acme_status' %}" hx-trigger="every 3s" hx-target="#acme-status-area" hx-swap="innerHTML">
     <div class="card-header" style="background:#eff6ff;">
       <i class="fas fa-spinner fa-spin" style="color:#3273dc;"></i> Certificate Issuance In Progress
     </div>
@@ -22,7 +24,7 @@
     <div class="card-body">
       <div style="font-size:0.85rem;color:#257953;">
         Certificate installed and nginx reloaded.
-        {% if cert_days_remaining %}Expires in {{ cert_days_remaining }} days.{% endif %}
+        {% if cert_days_remaining %} Expires in {{ cert_days_remaining }} days.{% endif %}
       </div>
       <p style="font-size:0.78rem;color:#7a7a7a;margin-top:0.5rem;">
         Renewed: {{ acme.last_renewed_at|date:"N j, Y g:i A" }}
@@ -42,16 +44,4 @@
     </div>
   </div>
 
-{% else %}
-  {# Nothing to show — no issuance attempted yet #}
-{% endif %}
-
-{% if acme_logs %}
-<div style="margin-top:0.75rem;">
-  {% for log in acme_logs %}
-  <div style="font-size:0.75rem;color:#7a7a7a;padding:0.15rem 0;">
-    {{ log.created_at|date:"g:i A" }} — {{ log.event }}: {{ log.detail|truncatechars:50 }}
-  </div>
-  {% endfor %}
-</div>
 {% endif %}

--- a/templates/certificates/settings.html
+++ b/templates/certificates/settings.html
@@ -196,6 +196,13 @@
             <span>Self-Signed</span>
           </a>
         </li>
+        <li data-tab="acme">
+          <a onclick="switchCertTab('acme')">
+            <span class="icon is-small"><i class="fas fa-lock"></i></span>
+            <span>Certificate Automation (ACME)</span>
+            {% if acme.is_enabled %}<span class="tag is-success is-light" style="margin-left:0.4rem;font-size:0.65rem;">Active</span>{% endif %}
+          </a>
+        </li>
       </ul>
     </div>
 
@@ -513,6 +520,281 @@
       </div>
     </div>
 
+    {# ===== Tab: Certificate Automation (ACME) ===== #}
+    <div class="tab-pane" id="tab-acme" style="display:none;">
+      <div class="proxmigrate-card" style="border-radius:0 10px 10px 10px;">
+        <div class="card-header">
+          <i class="fas fa-lock" style="color:#3273dc;"></i> Certificate Automation (ACME)
+        </div>
+        <div class="card-body">
+
+          {% if acme.is_enabled %}
+            {# ── State 3: Active & managed ── #}
+            <div class="notification is-success is-light" style="padding:0.75rem 1rem;margin-bottom:1.25rem;border-radius:6px;font-size:0.85rem;">
+              <i class="fas fa-check-circle" style="margin-right:0.4rem;"></i>
+              <strong>Automated certificate management is active.</strong>
+            </div>
+
+            <div class="cert-detail-row">
+              <div class="cert-detail-label">Provider</div>
+              <div class="cert-detail-value">{{ acme.get_provider_display }}</div>
+            </div>
+            <div class="cert-detail-row">
+              <div class="cert-detail-label">Domain</div>
+              <div class="cert-detail-value" style="font-family:monospace;">{{ acme.domain }}</div>
+            </div>
+            <div class="cert-detail-row">
+              <div class="cert-detail-label">Challenge</div>
+              <div class="cert-detail-value">{{ acme.get_challenge_type_display }}</div>
+            </div>
+            <div class="cert-detail-row">
+              <div class="cert-detail-label">Last Renewed</div>
+              <div class="cert-detail-value">{{ acme.last_renewed_at|date:"N j, Y g:i A"|default:"\u2014" }}</div>
+            </div>
+            {% if cert_days_remaining is not None %}
+            <div class="cert-detail-row">
+              <div class="cert-detail-label">Expires In</div>
+              <div class="cert-detail-value">{{ cert_days_remaining }} days</div>
+            </div>
+            {% endif %}
+            <div class="cert-detail-row">
+              <div class="cert-detail-label">Auto-Renewal</div>
+              <div class="cert-detail-value">
+                {% if acme.challenge_type == 'http-01' %}
+                  <span style="color:#257953;"><i class="fas fa-check"></i> Enabled (daily at 03:30 UTC)</span>
+                {% else %}
+                  <span style="color:#b45309;"><i class="fas fa-exclamation-triangle"></i> Manual (DNS-01 requires user action)</span>
+                {% endif %}
+              </div>
+            </div>
+
+            {% if acme.last_renewal_error %}
+            <div class="notification is-danger is-light" style="padding:0.6rem 0.9rem;margin-top:1rem;font-size:0.82rem;">
+              <i class="fas fa-times-circle" style="margin-right:0.4rem;"></i>
+              <strong>Last error:</strong> {{ acme.last_renewal_error }}
+            </div>
+            {% endif %}
+
+            <div style="display:flex;gap:0.5rem;margin-top:1.25rem;">
+              <form method="post" action="{% url 'acme_issue' %}">
+                {% csrf_token %}
+                <button type="submit" class="button is-primary" style="font-weight:600;">
+                  <span class="icon"><i class="fas fa-sync-alt"></i></span>
+                  <span>Renew Now</span>
+                </button>
+              </form>
+              <form method="post" action="{% url 'acme_disable' %}">
+                {% csrf_token %}
+                <button type="submit" class="button is-light" style="font-weight:600;"
+                  onclick="return confirm('Disable ACME automation? The current certificate will remain in place.')">
+                  <span class="icon"><i class="fas fa-power-off"></i></span>
+                  <span>Disable ACME</span>
+                </button>
+              </form>
+            </div>
+
+            {# Recent ACME log #}
+            {% if acme_logs %}
+            <div style="margin-top:1.5rem;padding-top:1rem;border-top:1px solid #f0f0f0;">
+              <div style="font-size:0.82rem;font-weight:600;color:#4a4a4a;margin-bottom:0.5rem;">Recent Activity</div>
+              {% for log in acme_logs %}
+              <div style="display:flex;justify-content:space-between;font-size:0.78rem;color:#7a7a7a;padding:0.25rem 0;border-bottom:1px solid #fafafa;">
+                <span>{{ log.created_at|date:"M j, g:i A" }}</span>
+                <span style="font-family:monospace;color:#4a4a4a;">{{ log.event }}</span>
+                <span style="max-width:50%;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{ log.detail|truncatechars:60 }}</span>
+              </div>
+              {% endfor %}
+            </div>
+            {% endif %}
+
+          {% elif acme.acme_account_url %}
+            {# ── State 2: Configured, ready to issue ── #}
+            <div class="notification is-info is-light" style="padding:0.75rem 1rem;margin-bottom:1.25rem;border-radius:6px;font-size:0.85rem;">
+              <i class="fas fa-info-circle" style="margin-right:0.4rem;"></i>
+              ACME account registered. Ready to issue a certificate.
+            </div>
+
+            <div class="cert-detail-row">
+              <div class="cert-detail-label">Provider</div>
+              <div class="cert-detail-value">{{ acme.get_provider_display }}</div>
+            </div>
+            <div class="cert-detail-row">
+              <div class="cert-detail-label">Domain</div>
+              <div class="cert-detail-value" style="font-family:monospace;">{{ acme.domain }}</div>
+            </div>
+            <div class="cert-detail-row">
+              <div class="cert-detail-label">Challenge</div>
+              <div class="cert-detail-value">{{ acme.get_challenge_type_display }}</div>
+            </div>
+            <div class="cert-detail-row">
+              <div class="cert-detail-label">Directory</div>
+              <div class="cert-detail-value" style="font-family:monospace;font-size:0.78rem;word-break:break-all;">{{ acme.directory_url }}</div>
+            </div>
+
+            {% if acme.dns_challenge_pending %}
+            <div class="notification is-warning is-light" style="padding:0.75rem 1rem;margin-top:1.25rem;border-radius:6px;">
+              <div style="font-size:0.85rem;font-weight:600;margin-bottom:0.5rem;">
+                <i class="fas fa-exclamation-triangle" style="margin-right:0.3rem;"></i>
+                DNS Record Required
+              </div>
+              <div style="font-size:0.82rem;margin-bottom:0.75rem;">
+                Create this DNS TXT record at your DNS provider:
+              </div>
+              <div style="background:#f9f9f9;padding:0.75rem;border-radius:4px;margin-bottom:0.75rem;">
+                <div style="font-size:0.78rem;color:#7a7a7a;">Name:</div>
+                <div style="font-family:monospace;font-size:0.85rem;font-weight:600;margin-bottom:0.4rem;">_acme-challenge.{{ acme.domain }}</div>
+                <div style="font-size:0.78rem;color:#7a7a7a;">Value:</div>
+                <div style="font-family:monospace;font-size:0.85rem;font-weight:600;word-break:break-all;">{{ acme.dns_txt_value }}</div>
+                <div style="font-size:0.78rem;color:#7a7a7a;margin-top:0.4rem;">TTL: 300 (or lowest available)</div>
+              </div>
+              <form method="post" action="{% url 'acme_dns_confirm' %}">
+                {% csrf_token %}
+                <button type="submit" class="button is-warning" style="font-weight:600;">
+                  <span class="icon"><i class="fas fa-check"></i></span>
+                  <span>I've Created the DNS Record</span>
+                </button>
+              </form>
+            </div>
+            {% else %}
+            <div style="margin-top:1.25rem;">
+              <form method="post" action="{% url 'acme_issue' %}">
+                {% csrf_token %}
+                <button type="submit" class="button is-primary is-fullwidth" style="font-weight:600;">
+                  <span class="icon"><i class="fas fa-certificate"></i></span>
+                  <span>Issue Certificate</span>
+                </button>
+              </form>
+            </div>
+            {% endif %}
+
+            {% if acme.last_renewal_error %}
+            <div class="notification is-danger is-light" style="padding:0.6rem 0.9rem;margin-top:1rem;font-size:0.82rem;">
+              <i class="fas fa-times-circle" style="margin-right:0.4rem;"></i>
+              <strong>Last error:</strong> {{ acme.last_renewal_error }}
+            </div>
+            {% endif %}
+
+          {% else %}
+            {# ── State 1: Not configured ── #}
+            <div class="info-box" style="margin-bottom:1.25rem;">
+              <div class="info-box-icon"><i class="fas fa-info-circle"></i></div>
+              <div style="font-size:0.82rem;">
+                Automate certificate issuance and renewal using the ACME protocol (RFC 8555).
+                Works with <strong>Let's Encrypt</strong> and internal enterprise certificate authorities
+                (Microsoft ADCS, Smallstep, Keyfactor, etc.).
+              </div>
+            </div>
+
+            <form method="post" action="{% url 'acme_configure' %}">
+              {% csrf_token %}
+
+              <div class="field" style="margin-bottom:1.25rem;">
+                <label class="label form-label">Provider</label>
+                <div class="control">
+                  <div class="select is-fullwidth">
+                    <select name="provider" id="acme-provider" onchange="onAcmeProviderChange()">
+                      <option value="letsencrypt">Let's Encrypt</option>
+                      <option value="letsencrypt_staging">Let's Encrypt (Staging)</option>
+                      <option value="custom">Custom / Internal CA</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+
+              <div class="field" id="acme-directory-field" style="margin-bottom:1.25rem;display:none;">
+                <label class="label form-label">Directory URL</label>
+                <div class="control">
+                  <input class="input" type="url" name="directory_url" id="acme-directory-url"
+                         placeholder="https://your-ca.example.com/acme/directory"
+                         style="font-family:monospace;font-size:0.85rem;">
+                </div>
+                <p class="field-hint">The ACME directory URL for your certificate authority.</p>
+              </div>
+
+              <div class="field" style="margin-bottom:1.25rem;">
+                <label class="label form-label">
+                  Domain (FQDN) <span style="color:#f14668;">*</span>
+                </label>
+                <div class="control">
+                  <input class="input" type="text" name="domain" required
+                         placeholder="proxmigrate.example.com"
+                         style="font-family:monospace;">
+                </div>
+                <p class="field-hint">The fully qualified domain name for the certificate.</p>
+              </div>
+
+              <div class="field" id="acme-email-field" style="margin-bottom:1.25rem;">
+                <label class="label form-label">
+                  Email <span id="acme-email-required" style="color:#f14668;">*</span>
+                </label>
+                <div class="control">
+                  <input class="input" type="email" name="email" id="acme-email"
+                         placeholder="admin@example.com">
+                </div>
+                <p class="field-hint">
+                  <span id="acme-email-hint">Required by Let's Encrypt for expiry notices.</span>
+                </p>
+              </div>
+
+              <div class="field" style="margin-bottom:1.25rem;">
+                <label class="label form-label">Challenge Type</label>
+                <div class="control">
+                  <label class="radio" style="font-size:0.85rem;display:block;margin-bottom:0.5rem;">
+                    <input type="radio" name="challenge_type" value="http-01" checked>
+                    <strong>HTTP-01</strong> &mdash; Port 80 must be open to the internet. Fully automatic renewal.
+                  </label>
+                  <label class="radio" style="font-size:0.85rem;display:block;">
+                    <input type="radio" name="challenge_type" value="dns-01">
+                    <strong>DNS-01</strong> &mdash; Works on private networks. Manual TXT record required for each renewal.
+                  </label>
+                </div>
+                <p class="field-hint" style="margin-top:0.5rem;">
+                  Some internal CAs may issue certificates without a challenge &mdash; if so, the challenge step will be skipped automatically.
+                </p>
+              </div>
+
+              {# Advanced section for internal CAs #}
+              <div class="form-section-header" style="cursor:pointer;margin-bottom:0;">
+                <span style="font-size:0.85rem;font-weight:600;color:#4a4a4a;">
+                  <i class="fas fa-chevron-down section-toggle-icon" style="margin-right:0.4rem;font-size:0.7rem;"></i>
+                  Advanced (Internal CA Options)
+                </span>
+              </div>
+              <div class="form-section-body" id="acme-advanced" style="padding-top:1rem;">
+                <div class="field" style="margin-bottom:1rem;">
+                  <label class="label form-label">CA Certificate (PEM)</label>
+                  <div class="control">
+                    <textarea class="textarea is-small" name="ca_bundle" rows="4"
+                      placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
+                      style="font-family:monospace;font-size:0.78rem;resize:vertical;"></textarea>
+                  </div>
+                  <p class="field-hint">PEM-encoded root certificate for verifying the ACME server's TLS. Only needed for internal CAs with private root certificates.</p>
+                </div>
+
+                <div class="field">
+                  <label class="checkbox" style="font-size:0.85rem;">
+                    <input type="checkbox" name="skip_tls_verify">
+                    Skip TLS verification
+                  </label>
+                  <p class="field-hint" style="margin-top:0.3rem;">
+                    <i class="fas fa-exclamation-triangle" style="color:#f59e0b;margin-right:0.3rem;"></i>
+                    Only use for testing. Disables TLS verification for the ACME server connection.
+                  </p>
+                </div>
+              </div>
+
+              <button type="submit" class="button is-primary is-fullwidth" style="font-weight:600;margin-top:1.25rem;">
+                <span class="icon"><i class="fas fa-user-plus"></i></span>
+                <span>Configure &amp; Register</span>
+              </button>
+            </form>
+
+          {% endif %}
+
+        </div>
+      </div>
+    </div>
+
   </div>
 </div>
 
@@ -540,6 +822,27 @@ function switchCertTab(name) {
     switchCertTab('upload-signed');
   });
 {% endif %}
+
+// ACME provider change handler
+function onAcmeProviderChange() {
+  var provider = document.getElementById('acme-provider').value;
+  var dirField = document.getElementById('acme-directory-field');
+  var emailRequired = document.getElementById('acme-email-required');
+  var emailHint = document.getElementById('acme-email-hint');
+  var emailInput = document.getElementById('acme-email');
+
+  if (provider === 'custom') {
+    dirField.style.display = '';
+    emailRequired.style.display = 'none';
+    emailInput.removeAttribute('required');
+    emailHint.textContent = 'Optional for internal CAs.';
+  } else {
+    dirField.style.display = 'none';
+    emailRequired.style.display = '';
+    emailInput.setAttribute('required', '');
+    emailHint.textContent = 'Required by Let\'s Encrypt for expiry notices.';
+  }
+}
 </script>
 
 {% endblock %}

--- a/templates/certificates/settings.html
+++ b/templates/certificates/settings.html
@@ -599,6 +599,11 @@
               </form>
             </div>
 
+            {# Live status area for renewals — same as State 2 #}
+            <div id="acme-status-area">
+              {% include "certificates/partials/acme_status.html" %}
+            </div>
+
             {# Recent ACME log #}
             {% if acme_logs %}
             <div style="margin-top:1.5rem;padding-top:1rem;border-top:1px solid #f0f0f0;">

--- a/templates/certificates/settings.html
+++ b/templates/certificates/settings.html
@@ -687,12 +687,13 @@
             </div>
             {% endif %}
 
-            {% if acme.last_renewal_error %}
-            <div class="notification is-danger is-light" data-persist="true" style="padding:0.6rem 0.9rem;margin-top:1rem;font-size:0.82rem;">
-              <i class="fas fa-times-circle" style="margin-right:0.4rem;"></i>
-              <strong>Last error:</strong> {{ acme.last_renewal_error }}
+            {# Live status area — polls during issuance #}
+            <div id="acme-status-area"
+                 hx-get="{% url 'acme_status' %}"
+                 hx-trigger="{% if acme.issuing_in_progress %}every 3s{% else %}none{% endif %}"
+                 hx-swap="innerHTML">
+              {% include "certificates/partials/acme_status.html" %}
             </div>
-            {% endif %}
 
           {% else %}
             {# ── State 1: Not configured ── #}

--- a/templates/certificates/settings.html
+++ b/templates/certificates/settings.html
@@ -34,6 +34,7 @@
             {% elif cert_days_remaining > 0 %}is-warning is-light
             {% else %}is-danger is-light
             {% endif %}"
+            data-persist="true"
             style="padding:0.6rem 0.9rem;margin-bottom:1.25rem;border-radius:6px;font-size:0.82rem;">
             {% if cert_days_remaining > 30 %}
               <i class="fas fa-check-circle" style="margin-right:0.4rem;"></i>
@@ -530,7 +531,7 @@
 
           {% if acme.is_enabled %}
             {# ── State 3: Active & managed ── #}
-            <div class="notification is-success is-light" style="padding:0.75rem 1rem;margin-bottom:1.25rem;border-radius:6px;font-size:0.85rem;">
+            <div class="notification is-success is-light" data-persist="true" style="padding:0.75rem 1rem;margin-bottom:1.25rem;border-radius:6px;font-size:0.85rem;">
               <i class="fas fa-check-circle" style="margin-right:0.4rem;"></i>
               <strong>Automated certificate management is active.</strong>
             </div>
@@ -569,7 +570,7 @@
             </div>
 
             {% if acme.last_renewal_error %}
-            <div class="notification is-danger is-light" style="padding:0.6rem 0.9rem;margin-top:1rem;font-size:0.82rem;">
+            <div class="notification is-danger is-light" data-persist="true" style="padding:0.6rem 0.9rem;margin-top:1rem;font-size:0.82rem;">
               <i class="fas fa-times-circle" style="margin-right:0.4rem;"></i>
               <strong>Last error:</strong> {{ acme.last_renewal_error }}
             </div>
@@ -609,7 +610,7 @@
 
           {% elif acme.acme_account_url %}
             {# ── State 2: Configured, ready to issue ── #}
-            <div class="notification is-info is-light" style="padding:0.75rem 1rem;margin-bottom:1.25rem;border-radius:6px;font-size:0.85rem;">
+            <div class="notification is-info is-light" data-persist="true" style="padding:0.75rem 1rem;margin-bottom:1.25rem;border-radius:6px;font-size:0.85rem;">
               <i class="fas fa-info-circle" style="margin-right:0.4rem;"></i>
               ACME account registered. Ready to issue a certificate.
             </div>
@@ -632,28 +633,39 @@
             </div>
 
             {% if acme.dns_challenge_pending %}
-            <div class="notification is-warning is-light" style="padding:0.75rem 1rem;margin-top:1.25rem;border-radius:6px;">
-              <div style="font-size:0.85rem;font-weight:600;margin-bottom:0.5rem;">
-                <i class="fas fa-exclamation-triangle" style="margin-right:0.3rem;"></i>
-                DNS Record Required
+            <div class="proxmigrate-card" style="margin-top:1.25rem;border-left:4px solid #f59e0b;border-radius:0 10px 10px 0;">
+              <div class="card-header" style="background:#fffbeb;">
+                <i class="fas fa-exclamation-triangle" style="color:#f59e0b;"></i> DNS Record Required
               </div>
-              <div style="font-size:0.82rem;margin-bottom:0.75rem;">
-                Create this DNS TXT record at your DNS provider:
+              <div class="card-body">
+                <div style="font-size:0.82rem;margin-bottom:0.75rem;">
+                  Create this DNS TXT record at your DNS provider:
+                </div>
+                <div style="background:#f9f9f9;padding:0.75rem;border-radius:4px;margin-bottom:0.75rem;">
+                  <div style="font-size:0.78rem;color:#7a7a7a;">Name:</div>
+                  <div style="font-family:monospace;font-size:0.85rem;font-weight:600;margin-bottom:0.4rem;">_acme-challenge.{{ acme.domain }}</div>
+                  <div style="font-size:0.78rem;color:#7a7a7a;">Value:</div>
+                  <div style="font-family:monospace;font-size:0.85rem;font-weight:600;word-break:break-all;">{{ acme.dns_txt_value }}</div>
+                  <div style="font-size:0.78rem;color:#7a7a7a;margin-top:0.4rem;">TTL: 300 (or lowest available)</div>
+                </div>
+                <div style="display:flex;gap:0.5rem;">
+                  <form method="post" action="{% url 'acme_dns_confirm' %}">
+                    {% csrf_token %}
+                    <button type="submit" class="button is-warning" style="font-weight:600;">
+                      <span class="icon"><i class="fas fa-check"></i></span>
+                      <span>I've Created the DNS Record</span>
+                    </button>
+                  </form>
+                  <form method="post" action="{% url 'acme_reset' %}">
+                    {% csrf_token %}
+                    <button type="submit" class="button is-light" style="font-weight:600;"
+                      onclick="return confirm('Cancel and reset ACME configuration?')">
+                      <span class="icon"><i class="fas fa-undo"></i></span>
+                      <span>Reconfigure</span>
+                    </button>
+                  </form>
+                </div>
               </div>
-              <div style="background:#f9f9f9;padding:0.75rem;border-radius:4px;margin-bottom:0.75rem;">
-                <div style="font-size:0.78rem;color:#7a7a7a;">Name:</div>
-                <div style="font-family:monospace;font-size:0.85rem;font-weight:600;margin-bottom:0.4rem;">_acme-challenge.{{ acme.domain }}</div>
-                <div style="font-size:0.78rem;color:#7a7a7a;">Value:</div>
-                <div style="font-family:monospace;font-size:0.85rem;font-weight:600;word-break:break-all;">{{ acme.dns_txt_value }}</div>
-                <div style="font-size:0.78rem;color:#7a7a7a;margin-top:0.4rem;">TTL: 300 (or lowest available)</div>
-              </div>
-              <form method="post" action="{% url 'acme_dns_confirm' %}">
-                {% csrf_token %}
-                <button type="submit" class="button is-warning" style="font-weight:600;">
-                  <span class="icon"><i class="fas fa-check"></i></span>
-                  <span>I've Created the DNS Record</span>
-                </button>
-              </form>
             </div>
             {% else %}
             <div style="display:flex;gap:0.5rem;margin-top:1.25rem;">
@@ -676,7 +688,7 @@
             {% endif %}
 
             {% if acme.last_renewal_error %}
-            <div class="notification is-danger is-light" style="padding:0.6rem 0.9rem;margin-top:1rem;font-size:0.82rem;">
+            <div class="notification is-danger is-light" data-persist="true" style="padding:0.6rem 0.9rem;margin-top:1rem;font-size:0.82rem;">
               <i class="fas fa-times-circle" style="margin-right:0.4rem;"></i>
               <strong>Last error:</strong> {{ acme.last_renewal_error }}
             </div>

--- a/templates/certificates/settings.html
+++ b/templates/certificates/settings.html
@@ -746,6 +746,16 @@
                 <p class="field-hint">The fully qualified domain name for the certificate.</p>
               </div>
 
+              <div class="field" style="margin-bottom:1.25rem;">
+                <label class="label form-label">IP SANs</label>
+                <div class="control">
+                  <input class="input" type="text" name="ip_sans"
+                         placeholder="192.168.1.100, 10.0.0.5"
+                         style="font-family:monospace;">
+                </div>
+                <p class="field-hint">Optional. Comma-separated IP addresses to include as Subject Alternative Names. Useful for internal CAs where the server is accessed by IP.</p>
+              </div>
+
               <div class="field" id="acme-email-field" style="margin-bottom:1.25rem;">
                 <label class="label form-label">
                   Email <span id="acme-email-required" style="color:#f14668;">*</span>

--- a/templates/certificates/settings.html
+++ b/templates/certificates/settings.html
@@ -824,12 +824,25 @@ function switchCertTab(name) {
   });
 }
 
-// Auto-switch to upload-signed if there is a pending CSR
-{% if pending_csr %}
-  document.addEventListener('DOMContentLoaded', function() {
+// Auto-switch tab based on state
+document.addEventListener('DOMContentLoaded', function() {
+  // URL param takes priority (used after ACME redirects)
+  var params = new URLSearchParams(window.location.search);
+  var tab = params.get('tab');
+  if (tab) {
+    switchCertTab(tab);
+    return;
+  }
+  // If ACME is configured or active, show ACME tab
+  {% if acme.acme_account_url or acme.is_enabled %}
+    switchCertTab('acme');
+    return;
+  {% endif %}
+  // If there is a pending CSR, show upload-signed tab
+  {% if pending_csr %}
     switchCertTab('upload-signed');
-  });
-{% endif %}
+  {% endif %}
+});
 
 // ACME provider change handler
 function onAcmeProviderChange() {

--- a/templates/certificates/settings.html
+++ b/templates/certificates/settings.html
@@ -562,9 +562,9 @@
               <div class="cert-detail-label">Auto-Renewal</div>
               <div class="cert-detail-value">
                 {% if acme.challenge_type == 'http-01' %}
-                  <span style="color:#257953;"><i class="fas fa-check"></i> Enabled (daily at 03:30 UTC)</span>
+                  <span style="color:#257953;"><i class="fas fa-check"></i> Automatic (renews at half cert validity)</span>
                 {% else %}
-                  <span style="color:#b45309;"><i class="fas fa-exclamation-triangle"></i> Manual (DNS-01 requires user action)</span>
+                  <span style="color:#257953;"><i class="fas fa-check"></i> Semi-automatic (emails TXT record to admins at half cert validity)</span>
                 {% endif %}
               </div>
             </div>

--- a/templates/certificates/settings.html
+++ b/templates/certificates/settings.html
@@ -687,11 +687,8 @@
             </div>
             {% endif %}
 
-            {# Live status area — polls during issuance #}
-            <div id="acme-status-area"
-                 hx-get="{% url 'acme_status' %}"
-                 hx-trigger="{% if acme.issuing_in_progress %}every 3s{% else %}none{% endif %}"
-                 hx-swap="innerHTML">
+            {# Live status area — partial controls its own polling #}
+            <div id="acme-status-area">
               {% include "certificates/partials/acme_status.html" %}
             </div>
 

--- a/templates/certificates/settings.html
+++ b/templates/certificates/settings.html
@@ -656,12 +656,20 @@
               </form>
             </div>
             {% else %}
-            <div style="margin-top:1.25rem;">
-              <form method="post" action="{% url 'acme_issue' %}">
+            <div style="display:flex;gap:0.5rem;margin-top:1.25rem;">
+              <form method="post" action="{% url 'acme_issue' %}" style="flex:1;">
                 {% csrf_token %}
                 <button type="submit" class="button is-primary is-fullwidth" style="font-weight:600;">
                   <span class="icon"><i class="fas fa-certificate"></i></span>
                   <span>Issue Certificate</span>
+                </button>
+              </form>
+              <form method="post" action="{% url 'acme_reset' %}">
+                {% csrf_token %}
+                <button type="submit" class="button is-light" style="font-weight:600;"
+                  onclick="return confirm('Reset ACME configuration? You can then reconfigure with different settings.')">
+                  <span class="icon"><i class="fas fa-undo"></i></span>
+                  <span>Reconfigure</span>
                 </button>
               </form>
             </div>

--- a/templates/certificates/settings.html
+++ b/templates/certificates/settings.html
@@ -31,7 +31,7 @@
           {# Expiry banner #}
           <div class="notification
             {% if cert_days_remaining > 30 %}is-success is-light
-            {% elif cert_days_remaining > 0 %}is-warning is-light
+            {% elif cert_days_remaining > 0 or cert_hours_remaining > 0 %}is-warning is-light
             {% else %}is-danger is-light
             {% endif %}"
             data-persist="true"
@@ -42,6 +42,9 @@
             {% elif cert_days_remaining > 0 %}
               <i class="fas fa-exclamation-triangle" style="margin-right:0.4rem;"></i>
               <strong>Expires soon</strong> — {{ cert_days_remaining }} days remaining.
+            {% elif cert_hours_remaining > 0 %}
+              <i class="fas fa-exclamation-triangle" style="margin-right:0.4rem;"></i>
+              <strong>Expires soon</strong> — {{ cert_hours_remaining }} hours remaining.
             {% else %}
               <i class="fas fa-times-circle" style="margin-right:0.4rem;"></i>
               <strong>Certificate has expired!</strong> Replace it immediately.

--- a/templates/certificates/settings.html
+++ b/templates/certificates/settings.html
@@ -563,6 +563,8 @@
               <div class="cert-detail-value">
                 {% if acme.challenge_type == 'http-01' %}
                   <span style="color:#257953;"><i class="fas fa-check"></i> Automatic (renews at half cert validity)</span>
+                {% elif acme.dns_provider and acme.dns_provider != 'none' and acme.dns_provider != 'manual' %}
+                  <span style="color:#257953;"><i class="fas fa-check"></i> Automatic via {{ acme.get_dns_provider_display }} (renews at half cert validity)</span>
                 {% else %}
                   <span style="color:#257953;"><i class="fas fa-check"></i> Semi-automatic (emails TXT record to admins at half cert validity)</span>
                 {% endif %}
@@ -758,17 +760,64 @@
                 <label class="label form-label">Challenge Type</label>
                 <div class="control">
                   <label class="radio" style="font-size:0.85rem;display:block;margin-bottom:0.5rem;">
-                    <input type="radio" name="challenge_type" value="http-01" checked>
-                    <strong>HTTP-01</strong> &mdash; Port 80 must be open to the internet. Fully automatic renewal.
+                    <input type="radio" name="challenge_type" value="http-01" checked onchange="onChallengeTypeChange()">
+                    <strong>HTTP-01</strong> &mdash; Port 80 must be open to the internet. Fully automatic.
                   </label>
                   <label class="radio" style="font-size:0.85rem;display:block;">
-                    <input type="radio" name="challenge_type" value="dns-01">
-                    <strong>DNS-01</strong> &mdash; Works on private networks. Manual TXT record required for each renewal.
+                    <input type="radio" name="challenge_type" value="dns-01" onchange="onChallengeTypeChange()">
+                    <strong>DNS-01</strong> &mdash; Works on private networks. Automatic with DNS provider API.
                   </label>
                 </div>
                 <p class="field-hint" style="margin-top:0.5rem;">
                   Some internal CAs may issue certificates without a challenge &mdash; if so, the challenge step will be skipped automatically.
                 </p>
+              </div>
+
+              {# DNS Provider — shown when DNS-01 is selected #}
+              <div id="dns-provider-section" style="display:none;margin-bottom:1.25rem;">
+                <div class="field" style="margin-bottom:1rem;">
+                  <label class="label form-label">DNS Provider</label>
+                  <div class="control">
+                    <div class="select is-fullwidth">
+                      <select name="dns_provider" id="dns-provider-select" onchange="onDnsProviderChange()">
+                        <option value="cloudflare">Cloudflare</option>
+                        <option value="route53">AWS Route 53</option>
+                        <option value="azure">Azure DNS</option>
+                        <option value="godaddy">GoDaddy</option>
+                        <option value="digitalocean">DigitalOcean</option>
+                        <option value="manual">Manual (email TXT record to admins)</option>
+                      </select>
+                    </div>
+                  </div>
+                </div>
+
+                <div id="dns-api-fields">
+                  <div class="field" style="margin-bottom:1rem;">
+                    <label class="label form-label" id="dns-token-label">API Token</label>
+                    <div class="control">
+                      <input class="input" type="password" name="dns_api_token"
+                             placeholder="Your API token" style="font-family:monospace;">
+                    </div>
+                    <p class="field-hint" id="dns-token-hint">API token with DNS edit permissions.</p>
+                  </div>
+
+                  <div class="field" id="dns-secret-field" style="margin-bottom:1rem;display:none;">
+                    <label class="label form-label" id="dns-secret-label">API Secret</label>
+                    <div class="control">
+                      <input class="input" type="password" name="dns_api_secret"
+                             placeholder="API secret key" style="font-family:monospace;">
+                    </div>
+                  </div>
+
+                  <div class="field" id="dns-zone-field" style="margin-bottom:1rem;">
+                    <label class="label form-label" id="dns-zone-label">Zone ID</label>
+                    <div class="control">
+                      <input class="input" type="text" name="dns_zone_id"
+                             placeholder="" id="dns-zone-input" style="font-family:monospace;">
+                    </div>
+                    <p class="field-hint" id="dns-zone-hint">Optional — auto-detected if not provided.</p>
+                  </div>
+                </div>
               </div>
 
               {# Advanced section for internal CAs #}
@@ -853,6 +902,71 @@ document.addEventListener('DOMContentLoaded', function() {
     switchCertTab('upload-signed');
   {% endif %}
 });
+
+// Challenge type change — show/hide DNS provider section
+function onChallengeTypeChange() {
+  var isDns = document.querySelector('input[name="challenge_type"]:checked');
+  var section = document.getElementById('dns-provider-section');
+  if (isDns && isDns.value === 'dns-01') {
+    section.style.display = '';
+    onDnsProviderChange();
+  } else {
+    section.style.display = 'none';
+  }
+}
+
+// DNS provider change — adjust labels and show/hide fields per provider
+function onDnsProviderChange() {
+  var provider = document.getElementById('dns-provider-select').value;
+  var apiFields = document.getElementById('dns-api-fields');
+  var secretField = document.getElementById('dns-secret-field');
+  var zoneField = document.getElementById('dns-zone-field');
+  var tokenLabel = document.getElementById('dns-token-label');
+  var tokenHint = document.getElementById('dns-token-hint');
+  var zoneLabel = document.getElementById('dns-zone-label');
+  var zoneHint = document.getElementById('dns-zone-hint');
+  var zoneInput = document.getElementById('dns-zone-input');
+
+  if (provider === 'manual') {
+    apiFields.style.display = 'none';
+    return;
+  }
+  apiFields.style.display = '';
+  secretField.style.display = 'none';
+  zoneField.style.display = '';
+
+  if (provider === 'cloudflare') {
+    tokenLabel.textContent = 'API Token';
+    tokenHint.textContent = 'Cloudflare API token with Zone:DNS:Edit permission.';
+    zoneLabel.textContent = 'Zone ID';
+    zoneHint.textContent = 'Optional — auto-detected from domain if not provided.';
+    zoneInput.placeholder = 'e.g. 1234567890abcdef';
+  } else if (provider === 'route53') {
+    tokenLabel.textContent = 'AWS Access Key ID';
+    tokenHint.textContent = 'IAM user access key with Route 53 permissions.';
+    secretField.style.display = '';
+    document.getElementById('dns-secret-label').textContent = 'AWS Secret Access Key';
+    zoneLabel.textContent = 'Hosted Zone ID';
+    zoneHint.textContent = 'Required. Found in the Route 53 console.';
+    zoneInput.placeholder = 'e.g. Z1234567890ABC';
+  } else if (provider === 'azure') {
+    tokenLabel.textContent = 'Bearer Token';
+    tokenHint.textContent = 'Azure AD service principal token with DNS Contributor role.';
+    zoneLabel.textContent = 'DNS Zone Resource ID';
+    zoneHint.textContent = 'Full resource ID: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/dnsZones/{zone}';
+    zoneInput.placeholder = '/subscriptions/...';
+  } else if (provider === 'godaddy') {
+    tokenLabel.textContent = 'API Key';
+    tokenHint.textContent = 'GoDaddy API key from developer.godaddy.com.';
+    secretField.style.display = '';
+    document.getElementById('dns-secret-label').textContent = 'API Secret';
+    zoneField.style.display = 'none';
+  } else if (provider === 'digitalocean') {
+    tokenLabel.textContent = 'Personal Access Token';
+    tokenHint.textContent = 'DigitalOcean token with read/write scope.';
+    zoneField.style.display = 'none';
+  }
+}
 
 // ACME provider change handler
 function onAcmeProviderChange() {

--- a/templates/certificates/settings.html
+++ b/templates/certificates/settings.html
@@ -705,7 +705,7 @@
               </div>
             </div>
 
-            <form method="post" action="{% url 'acme_configure' %}">
+            <form method="post" action="{% url 'acme_configure' %}" enctype="multipart/form-data">
               {% csrf_token %}
 
               <div class="field" style="margin-bottom:1.25rem;">
@@ -829,13 +829,40 @@
               </div>
               <div class="form-section-body" id="acme-advanced" style="padding-top:1rem;">
                 <div class="field" style="margin-bottom:1rem;">
-                  <label class="label form-label">CA Certificate (PEM)</label>
-                  <div class="control">
-                    <textarea class="textarea is-small" name="ca_bundle" rows="4"
-                      placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
-                      style="font-family:monospace;font-size:0.78rem;resize:vertical;"></textarea>
+                  <label class="label form-label">CA Certificate</label>
+                  <div style="display:flex;gap:0.5rem;margin-bottom:0.75rem;">
+                    <button type="button" id="ca-mode-upload" class="button is-small is-primary" onclick="setCaBundleMode('upload')" style="font-weight:600;">
+                      <span class="icon is-small"><i class="fas fa-upload"></i></span>
+                      <span>Upload File</span>
+                    </button>
+                    <button type="button" id="ca-mode-paste" class="button is-small is-light" onclick="setCaBundleMode('paste')" style="font-weight:600;">
+                      <span class="icon is-small"><i class="fas fa-paste"></i></span>
+                      <span>Paste PEM</span>
+                    </button>
                   </div>
-                  <p class="field-hint">PEM-encoded root certificate for verifying the ACME server's TLS. Only needed for internal CAs with private root certificates.</p>
+                  <div id="ca-bundle-upload">
+                    <div class="control">
+                      <div class="file has-name is-fullwidth">
+                        <label class="file-label">
+                          <input class="file-input" type="file" name="ca_bundle_file" accept=".pem,.crt,.cer"
+                            onchange="this.closest('.file').querySelector('.file-name').textContent = this.files[0].name">
+                          <span class="file-cta">
+                            <span class="file-icon"><i class="fas fa-upload"></i></span>
+                            <span class="file-label">Choose file</span>
+                          </span>
+                          <span class="file-name">No file selected</span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                  <div id="ca-bundle-paste" style="display:none;">
+                    <div class="control">
+                      <textarea class="textarea is-small" name="ca_bundle" rows="4"
+                        placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
+                        style="font-family:monospace;font-size:0.78rem;resize:vertical;"></textarea>
+                    </div>
+                  </div>
+                  <p class="field-hint" style="margin-top:0.5rem;">Root or intermediate CA certificate for verifying the ACME server's TLS. Only needed for internal CAs with private root certificates.</p>
                 </div>
 
                 <div class="field">
@@ -902,6 +929,15 @@ document.addEventListener('DOMContentLoaded', function() {
     switchCertTab('upload-signed');
   {% endif %}
 });
+
+// CA bundle mode toggle — upload file vs paste PEM
+function setCaBundleMode(mode) {
+  var isUpload = mode === 'upload';
+  document.getElementById('ca-bundle-upload').style.display = isUpload ? '' : 'none';
+  document.getElementById('ca-bundle-paste').style.display = isUpload ? 'none' : '';
+  document.getElementById('ca-mode-upload').className = 'button is-small ' + (isUpload ? 'is-primary' : 'is-light');
+  document.getElementById('ca-mode-paste').className = 'button is-small ' + (isUpload ? 'is-light' : 'is-primary');
+}
 
 // Challenge type change — show/hide DNS provider section
 function onChallengeTypeChange() {

--- a/templates/core/dashboard.html
+++ b/templates/core/dashboard.html
@@ -36,6 +36,14 @@
 </div>
 {% endif %}
 
+{% if cert_expiry_warning %}
+<div class="notification is-warning" style="margin-bottom:1.5rem;padding:0.75rem 1rem;border-radius:8px;font-size:0.85rem;">
+  <i class="fas fa-exclamation-triangle" style="margin-right:0.4rem;"></i>
+  TLS certificate expires in <strong>{{ cert_days_remaining }} days</strong>.
+  <a href="{% url 'cert_settings' %}" style="margin-left:0.5rem;">Manage certificates &rarr;</a>
+</div>
+{% endif %}
+
 {% if wizard_complete %}
 
 {# ===== VM STAT CARDS ===== #}

--- a/update.sh
+++ b/update.sh
@@ -57,6 +57,59 @@ sudo -u "${APP_USER}" \
     "${PYTHON}" "${APP_HOME}/manage.py" collectstatic --noinput \
     --settings=proxmigrate.settings.production
 
+# ---------------------------------------------------------------------------
+# Ensure ACME certificate automation prerequisites exist
+# ---------------------------------------------------------------------------
+echo "==> Checking ACME prerequisites..."
+
+# ACME challenge directory
+ACME_CHALLENGE_DIR="${APP_HOME}/certs/acme-challenge"
+if [[ ! -d "${ACME_CHALLENGE_DIR}" ]]; then
+    mkdir -p "${ACME_CHALLENGE_DIR}"
+    chown "${APP_USER}:${APP_USER}" "${ACME_CHALLENGE_DIR}"
+    echo "    Created ${ACME_CHALLENGE_DIR}"
+fi
+
+# Empty ACME challenge nginx config
+ACME_CONF="${APP_HOME}/deploy/acme-challenge.conf"
+if [[ ! -f "${ACME_CONF}" ]]; then
+    touch "${ACME_CONF}"
+    chown "${APP_USER}:${APP_USER}" "${ACME_CONF}"
+    echo "    Created ${ACME_CONF}"
+fi
+
+# Add ACME include to live nginx config if not present
+NGINX_CONF=""
+for p in /etc/nginx/sites-enabled/proxmigrate /etc/nginx/sites-available/proxmigrate /etc/nginx/conf.d/proxmigrate.conf; do
+    if [[ -f "${p}" ]]; then
+        NGINX_CONF="${p}"
+        break
+    fi
+done
+
+if [[ -n "${NGINX_CONF}" ]] && ! grep -q "acme-challenge.conf" "${NGINX_CONF}" 2>/dev/null; then
+    echo "" >> "${NGINX_CONF}"
+    echo "# ACME HTTP-01 challenge server (managed by ProxMigrate)" >> "${NGINX_CONF}"
+    echo "include ${ACME_CONF};" >> "${NGINX_CONF}"
+    echo "    Added ACME include to ${NGINX_CONF}"
+    nginx -t 2>/dev/null && nginx -s reload 2>/dev/null && echo "    nginx reloaded"
+fi
+
+# Add ACME sudoers rule if not present
+SUDOERS_FILE="/etc/sudoers.d/proxmigrate-nginx"
+if [[ -f "${SUDOERS_FILE}" ]] && ! grep -q "acme-challenge" "${SUDOERS_FILE}" 2>/dev/null; then
+    echo "${APP_USER} ALL=(ALL) NOPASSWD: /usr/bin/tee ${ACME_CONF}" >> "${SUDOERS_FILE}"
+    echo "    Added ACME sudoers rule"
+fi
+
+# Update celery service to include Beat scheduler (-B flag)
+CELERY_SERVICE="/etc/systemd/system/proxmigrate-celery.service"
+if [[ -f "${CELERY_SERVICE}" ]] && ! grep -q "\-B" "${CELERY_SERVICE}" 2>/dev/null; then
+    cp "${APP_HOME}/deploy/celery.service.template" "${CELERY_SERVICE}"
+    systemctl daemon-reload
+    echo "    Updated celery service with Beat scheduler"
+fi
+
 echo "==> Restarting services..."
 systemctl restart proxmigrate-gunicorn proxmigrate-celery
 systemctl is-active proxmigrate-gunicorn proxmigrate-celery


### PR DESCRIPTION
## Summary

- **ACME protocol client** (RFC 8555) — works with Let's Encrypt and any internal ACME-compliant CA (Microsoft ADCS, Smallstep, Keyfactor)
- **DNS provider APIs** — Cloudflare, AWS Route 53, Azure DNS, GoDaddy, DigitalOcean for fully automated DNS-01 challenges
- **One-click setup** — Configure & Register tests the DNS API, registers the ACME account, and auto-issues the cert in a single click
- **Real-time progress** — HTMX polling shows each issuance stage with a 10-second countdown + auto-refresh on success
- **Auto-renewal** — Celery Beat daily check, renews at half cert validity (hours-based, handles 24h certs)
- **IP SAN auto-discovery** — internal CAs automatically include server IPs in the cert (filters VPN/CGNAT IPs)
- **Dashboard warning** — yellow banner when cert expires within 30 days
- **Email alerts** — staff notified at 30/14/7 day thresholds
- **update.sh** — idempotently adds nginx includes, sudoers rules, and directories for existing installs

### New files
- `apps/certificates/models.py` — AcmeConfig + AcmeLog models
- `apps/certificates/acme.py` — ACME protocol implementation
- `apps/certificates/dns_providers.py` — DNS provider API integrations
- `apps/certificates/tasks.py` — Celery tasks (issue + expiry check)
- `apps/certificates/helpers.py` — Extracted cert helpers from views
- `deploy/acme-challenge.conf` — Temporary nginx port 80 config for HTTP-01

### Tested with
- Let's Encrypt production (DNS-01 via Cloudflare API) — proxmoxmigrate.backupassure.io
- Smallstep step-ca internal ACME (HTTP-01) — proxmigrate.backupassure.io
- Auto-renewal with 24-hour certs on internal CA

## Test plan
- [ ] Configure with Let's Encrypt Staging + DNS-01 manual — verify TXT record displays and cert issues after confirm
- [ ] Configure with Let's Encrypt + DNS-01 via Cloudflare API — verify one-click auto-issue
- [ ] Configure with internal CA (Smallstep) + HTTP-01 — verify cert issues with IP SANs
- [ ] Click Renew Now — verify progress card, success message, countdown, auto-refresh
- [ ] Click Reconfigure — verify settings reset and form reappears
- [ ] Verify update.sh adds nginx include and sudoers on existing install
- [ ] Wait for daily Celery Beat check — verify auto-renewal triggers at half validity

🤖 Generated with [Claude Code](https://claude.com/claude-code)